### PR TITLE
Pipe all output from generic output to stderr

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -279,8 +279,8 @@ ${CLUSTER_GEN}/remote-healthcheck-image: ${CLUSTER_GEN}/healthcheck-image-tagged
 	@  echo 'error: cluster config not loaded. Run kctf-config-create or kctf-config-load'
 	@  exit 1
 	@fi
-	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
-	mkdir -p ${CLUSTER_GEN}
+	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}" >&2
+	mkdir -p ${CLUSTER_GEN} >&2
 
 .FORCE:
 

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -1,2 +1,2 @@
-!kctf-conf/base
-kctf-conf/*
+kctf-conf/**
+!kctf-conf/base/

--- a/samples/kctf-conf/base/Makefile
+++ b/samples/kctf-conf/base/Makefile
@@ -279,8 +279,8 @@ ${CLUSTER_GEN}/remote-healthcheck-image: ${CLUSTER_GEN}/healthcheck-image-tagged
 	@  echo 'error: cluster config not loaded. Run kctf-config-create or kctf-config-load'
 	@  exit 1
 	@fi
-	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
-	mkdir -p ${CLUSTER_GEN}
+	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}" >&2
+	mkdir -p ${CLUSTER_GEN} >&2
 
 .FORCE:
 

--- a/samples/kctf-conf/base/Makefile
+++ b/samples/kctf-conf/base/Makefile
@@ -279,8 +279,8 @@ ${CLUSTER_GEN}/remote-healthcheck-image: ${CLUSTER_GEN}/healthcheck-image-tagged
 	@  echo 'error: cluster config not loaded. Run kctf-config-create or kctf-config-load'
 	@  exit 1
 	@fi
-	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}" >&2
-	mkdir -p ${CLUSTER_GEN} >&2
+	kubectl config use-context "kctf_${PROJECT}_${ZONE}_${CLUSTER_NAME}" > /dev/null
+	mkdir -p ${CLUSTER_GEN} > /dev/null
 
 .FORCE:
 


### PR DESCRIPTION
This is needed because `make ip` expects a clean stdout