### PR TITLE
Size and speed docker improvements

### DIFF
--- a/base/challenge-skeleton/healthcheck/Dockerfile
+++ b/base/challenge-skeleton/healthcheck/Dockerfile
@@ -17,9 +17,6 @@ FROM kctf-healthcheck
 # This is out of caution in case that we leak the 
 COPY .gen/exploit.cpio.enc /
 
-# Needed by the webserver healthz.py
-RUN apt-get -y install python2.7
-
 COPY files /home/user
 
 CMD decrypt_exploit.sh && setpriv --init-groups --reuid user --regid user --inh-caps=-all -- /exploit/run.sh & /home/user/healthz.py

--- a/base/healthcheck-docker/Dockerfile
+++ b/base/healthcheck-docker/Dockerfile
@@ -14,14 +14,12 @@
 FROM gcr.io/kctf-docker/kctf-pwntools:latest AS pwntools
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get upgrade -y
+# needed by decrypt_exploit.sh
+RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python2.7 && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 
 COPY --from=pwntools /venv /venv
 RUN mkdir -p /home/user/.pwntools-cache && echo never > /home/user/.pwntools-cache/update
-
-# needed by decrypt_exploit.sh
-RUN apt-get -y install cpio openssl
 
 COPY files/decrypt_exploit.sh /usr/bin/

--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -15,8 +15,9 @@ FROM gcr.io/kctf-docker/kctf-nsjail-chroot:latest AS chroot
 FROM gcr.io/kctf-docker/kctf-nsjail-bin:latest AS bin
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y uidmap libprotobuf17 libnl-route-3-200
-RUN apt-get upgrade -y
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends debootstrap \
     && rm -rf /var/lib/apt/lists/* \
     && debootstrap --variant minbase --include python3 eoan /chroot \
+    && cp /etc/resolv.conf /chroot/etc/resolv.conf \
     && chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user \
     && apt-get remove --purge -y debootstrap $(apt-mark showauto)

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -13,8 +13,7 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y debootstrap
-RUN apt-get upgrade -y
+RUN apt-get update && apt-get install -y --no-install-recommends debootstrap
 
 RUN debootstrap --variant minbase --include python3 eoan /chroot
 RUN chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -13,8 +13,9 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y --no-install-recommends debootstrap
-
-RUN debootstrap --variant minbase --include python3 eoan /chroot
-RUN chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user
-RUN /usr/sbin/useradd --no-create-home -u 1000 user
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends debootstrap \
+    && rm -rf /var/lib/apt/lists/* \
+    && debootstrap --variant minbase --include python3 eoan /chroot \
+    && chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user \
+    && apt-get remove --purge -y debootstrap $(apt-mark showauto)

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update \
     && apt-get install -yq --no-install-recommends debootstrap \
     && rm -rf /var/lib/apt/lists/* \
     && debootstrap --variant minbase --include python3 eoan /chroot \
-    && cp /etc/resolv.conf /chroot/etc/resolv.conf \
+    && echo nameserver 8.8.8.8 > /chroot/etc/resolv.conf \
     && chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user \
     && apt-get remove --purge -y debootstrap $(apt-mark showauto)

--- a/config/docker/nsjail.Dockerfile
+++ b/config/docker/nsjail.Dockerfile
@@ -13,7 +13,8 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev
+RUN apt-get -y upgrade
 RUN git clone https://github.com/google/nsjail.git
 RUN cd /nsjail && make -j && cp nsjail /usr/bin/
 RUN rm -R /nsjail

--- a/config/docker/nsjail.Dockerfile
+++ b/config/docker/nsjail.Dockerfile
@@ -13,8 +13,11 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev
-RUN apt-get -y upgrade
-RUN git clone https://github.com/google/nsjail.git
-RUN cd /nsjail && make -j && cp nsjail /usr/bin/
-RUN rm -R /nsjail
+ENV BUILD_PACKAGES build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev ca-certificates
+
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends $BUILD_PACKAGES \
+    && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/google/nsjail.git \
+    && cd /nsjail && make -j && cp nsjail /usr/bin/ \
+    && rm -R /nsjail && apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto)

--- a/config/docker/pwntools.Dockerfile
+++ b/config/docker/pwntools.Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get -y install build-essential python-virtualenv python2-dev
+RUN apt-get update && apt-get -y --no-install-recommends install build-essential python-virtualenv python2-dev
+RUN apt-get -y upgrade && apt-get -y clean
 
 RUN virtualenv /venv
 RUN bash -c "source /venv/bin/activate && pip install pwntools"

--- a/config/docker/pwntools.Dockerfile
+++ b/config/docker/pwntools.Dockerfile
@@ -13,8 +13,11 @@
 # limitations under the License.
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get -y --no-install-recommends install build-essential python-virtualenv python2-dev
-RUN apt-get -y upgrade && apt-get -y clean
+ENV BUILD_PACKAGES build-essential python-virtualenv virtualenv python2-dev
 
-RUN virtualenv /venv
-RUN bash -c "source /venv/bin/activate && pip install pwntools"
+RUN apt-get update \
+    && apt-get -yq --no-install-recommends install $BUILD_PACKAGES \
+    && rm -rf /var/lib/apt/lists/* \
+    && python2 -m virtualenv /venv \
+    && bash -c "source /venv/bin/activate && pip install pwntools" \
+    && apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto)

--- a/samples/apache-php/challenge/Dockerfile
+++ b/samples/apache-php/challenge/Dockerfile
@@ -1,16 +1,16 @@
 FROM kctf-nsjail
 
-RUN apt-get -y update
-RUN apt-get -y upgrade
-
 RUN ln -s /secrets/flag /chroot/flag
 
 VOLUME /tmp
 VOLUME /var/log/apache2
 VOLUME /var/run/apache2
 
-RUN apt-get install -y apache2
-RUN chroot /chroot apt-get install -y php-cgi
+RUN apt-get update && apt-get install -yq --no-install-recommends apache2 \
+    && rm -rf /var/lib/apt/lists/*
+RUN chroot /chroot apt-get update \
+    && chroot /chroot apt-get install -yq --no-install-recommends php-cgi \
+    && rm -rf /chroot/var/lib/apt/lists/*
 
 RUN service apache2 start
 

--- a/samples/kctf-conf/base/healthcheck-docker/Dockerfile
+++ b/samples/kctf-conf/base/healthcheck-docker/Dockerfile
@@ -14,14 +14,12 @@
 FROM gcr.io/kctf-docker/kctf-pwntools:latest AS pwntools
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get upgrade -y
+# needed by decrypt_exploit.sh
+RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python2.7 && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 
 COPY --from=pwntools /venv /venv
 RUN mkdir -p /home/user/.pwntools-cache && echo never > /home/user/.pwntools-cache/update
-
-# needed by decrypt_exploit.sh
-RUN apt-get -y install cpio openssl
 
 COPY files/decrypt_exploit.sh /usr/bin/

--- a/samples/kctf-conf/base/nsjail-docker/Dockerfile
+++ b/samples/kctf-conf/base/nsjail-docker/Dockerfile
@@ -15,8 +15,9 @@ FROM gcr.io/kctf-docker/kctf-nsjail-chroot:latest AS chroot
 FROM gcr.io/kctf-docker/kctf-nsjail-bin:latest AS bin
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get install -y uidmap libprotobuf17 libnl-route-3-200
-RUN apt-get upgrade -y
+RUN apt-get update \
+    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 

--- a/samples/kctf-conf/base/nsjail-docker/Dockerfile
+++ b/samples/kctf-conf/base/nsjail-docker/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/kctf-docker/kctf-nsjail-bin:latest AS bin
 FROM ubuntu:19.10
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
+    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 gnupg wget netcat ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user

--- a/samples/xss-bot/challenge/Dockerfile
+++ b/samples/xss-bot/challenge/Dockerfile
@@ -1,29 +1,18 @@
 FROM kctf-nsjail
 
-RUN apt-get -y update
-RUN apt-get -y upgrade
-
-RUN mkdir /home/user
-
-RUN apt-get install -y nodejs npm
-RUN cd /home/user && npm install puppeteer
-
-# See https://crbug.com/795759
-RUN apt-get install -yq libgconf-2-4
-
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
-# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
-# installs, work.
-RUN apt-get update && apt-get install -y wget --no-install-recommends \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer installs, work.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
     && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst \
-      --no-install-recommends
+    && apt-get install -yq --no-install-recommends \
+       libgconf-2-4 google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst \
+       nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN cd /home/user && npm install proof-of-work
-
+RUN mkdir /home/user
 COPY files /home/user
+RUN cd /home/user && npm install puppeteer proof-of-work
 
 # Since we don't need nsjail here, we could also run as user in the k8s config
 CMD exec setpriv --init-groups --reset-env --reuid user --regid user --inh-caps=-all -- /usr/bin/bash -c 'while true; do /usr/bin/node /home/user/bot.js; done'

--- a/samples/xss-bot/healthcheck/Dockerfile
+++ b/samples/xss-bot/healthcheck/Dockerfile
@@ -3,10 +3,6 @@ FROM kctf-healthcheck
 # Add the exploit directory as an encrypted archive.
 # This is out of caution in case that we leak the 
 COPY .gen/exploit.cpio.enc /
-
-# Needed by the webserver healthz.py
-RUN apt-get -y install python2.7
-
 COPY files /home/user
 
 CMD decrypt_exploit.sh && setpriv --init-groups --reuid user --regid user --inh-caps=-all -- /exploit/run.sh & /home/user/healthz.py


### PR DESCRIPTION
Following best practices from https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run and tips from https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends so we install less packages.

For the preinstalled packages, following advice from https://www.dajobe.org/blog/2015/04/18/making-debian-docker-images-smaller/ so these are smaller.

Inspired by https://github.com/google/google-ctf/pull/48