### PR TITLE
Make local testing with cached images possible

### DIFF
--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -63,34 +63,16 @@ jobs:
 
       - name: Push images
         run: |
-          IMAGE_REPO=docker.pkg.github.com/${{ github.repository }}
-          IMAGE_GCR=gcr.io/${{ secrets.GCR_PROJECT }}
+          PUSH="true"
+          REFERENCE="${{ github.ref }}"
+          IMAGE_REPO="docker.pkg.github.com/${{ github.repository }}"
+          IMAGE_GCR="gcr.io/${{ secrets.GCR_PROJECT }}"
 
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          scripts/dev/docker.sh nsjail $IMAGE_REPO/kctf-nsjail-bin $REFERENCE $PUSH
+          scripts/dev/docker.sh nsjail $IMAGE_GCR/kctf-nsjail-bin $REFERENCE $PUSH
 
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          scripts/dev/docker.sh chroot $IMAGE_REPO/kctf-nsjail-chroot $REFERENCE $PUSH
+          scripts/dev/docker.sh chroot $IMAGE_GCR/kctf-nsjail-chroot $REFERENCE $PUSH
 
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          echo VERSION=$VERSION
-
-          docker tag nsjail $IMAGE_REPO/kctf-nsjail-bin:$VERSION
-          docker tag nsjail $IMAGE_GCR/kctf-nsjail-bin:$VERSION
-
-          docker tag chroot $IMAGE_REPO/kctf-nsjail-chroot:$VERSION
-          docker tag chroot $IMAGE_GCR/kctf-nsjail-chroot:$VERSION
-
-          docker tag pwntools $IMAGE_REPO/kctf-pwntools:$VERSION
-          docker tag pwntools $IMAGE_GCR/kctf-pwntools:$VERSION
-          
-          docker push $IMAGE_REPO/kctf-nsjail-bin:$VERSION
-          docker push $IMAGE_GCR/kctf-nsjail-bin:$VERSION
-          
-          docker push $IMAGE_REPO/kctf-nsjail-chroot:$VERSION
-          docker push $IMAGE_GCR/kctf-nsjail-chroot:$VERSION
-          
-          docker push $IMAGE_REPO/kctf-pwntools:$VERSION
-          docker push $IMAGE_GCR/kctf-pwntools:$VERSION
+          scripts/dev/docker.sh pwntools $IMAGE_REPO/kctf-pwntools $REFERENCE $PUSH
+          scripts/dev/docker.sh pwntools $IMAGE_GCR/kctf-pwntools $REFERENCE $PUSH

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -79,15 +79,18 @@ jobs:
 
           docker tag nsjail $IMAGE_REPO/kctf-nsjail-bin:$VERSION
           docker tag nsjail $IMAGE_GCR/kctf-nsjail-bin:$VERSION
-          docker push $IMAGE_REPO/kctf-nsjail-bin:$VERSION
-          docker push $IMAGE_GCR/kctf-nsjail-bin:$VERSION
 
           docker tag chroot $IMAGE_REPO/kctf-nsjail-chroot:$VERSION
           docker tag chroot $IMAGE_GCR/kctf-nsjail-chroot:$VERSION
-          docker push $IMAGE_REPO/kctf-nsjail-chroot:$VERSION
-          docker push $IMAGE_GCR/kctf-nsjail-chroot:$VERSION
 
           docker tag pwntools $IMAGE_REPO/kctf-pwntools:$VERSION
           docker tag pwntools $IMAGE_GCR/kctf-pwntools:$VERSION
+          
+          docker push $IMAGE_REPO/kctf-nsjail-bin:$VERSION
+          docker push $IMAGE_GCR/kctf-nsjail-bin:$VERSION
+          
+          docker push $IMAGE_REPO/kctf-nsjail-chroot:$VERSION
+          docker push $IMAGE_GCR/kctf-nsjail-chroot:$VERSION
+          
           docker push $IMAGE_REPO/kctf-pwntools:$VERSION
           docker push $IMAGE_GCR/kctf-pwntools:$VERSION

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -1,4 +1,4 @@
-name: Push docker base image cache
+name: Push docker base image cache to GCR cache
 
 on:
   push:

--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -1,4 +1,4 @@
-name: GKE Deployment 
+name: Push samples to testing GKE deployment 
 
 on:
   push:
@@ -40,10 +40,26 @@ jobs:
       run: |
         gcloud auth configure-docker
 
+    - name: Build base images locally if any cached files changed
+      run: |
+        FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep ^config/docker/)
+        if [ ! -z "$FILES" ]; then
+          pushd config/docker
+          docker build . --file nsjail.Dockerfile -t nsjail
+          docker build . --file chroot.Dockerfile -t chroot
+          docker build . --file pwntools.Dockerfile -t pwntools
+          popd
+          scripts/dev/docker.sh nsjail gcr.io/kctf-nsjail/kctf-nsjail-bin latest
+          scripts/dev/docker.sh chroot gcr.io/kctf-nsjail/kctf-nsjail-chroot latest
+          scripts/dev/docker.sh pwntools gcr.io/kctf-nsjail/kctf-pwntools latest
+        fi
+        
+    
     - name: Configure kCTF directory
       run: |        
         export PATH=$PATH:$PWD/bin
         kctf-setup-chal-dir $PWD/samples
+        kctf-chal-create default-task
 
     - name: Configure kCTF cluster
       run: |
@@ -52,7 +68,7 @@ jobs:
         echo ZONE=$GKE_ZONE >> /tmp/kctf.conf
         echo CLUSTER_NAME=$GKE_CLUSTER >> /tmp/kctf.conf
         echo DOMAIN_NAME=$GKE_CLUSTER.kctf.dev >> /tmp/kctf.conf
-        # hack until #19 is fixed
+        # hack until https://github.com/google/kctf/issues/19 is fixed
         KCTF_DIRECTORY=${GKE_PROJECT}_${GKE_ZONE}_${GKE_CLUSTER}
         mkdir -p samples/kctf-conf/$KCTF_DIRECTORY/
         mv /tmp/kctf.conf samples/kctf-conf/$KCTF_DIRECTORY/cluster.conf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build base images locally if any cached files changed
       run: |
-        FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep ^config/docker/)
+        FILES=$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep ^config/docker/) || true
         if [ ! -z "$FILES" ]; then
           pushd config/docker
           docker build . --file nsjail.Dockerfile -t nsjail

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,10 @@
-name: Push samples to testing GKE deployment 
+name: Test build and GKE deployment
 
 on:
   push:
     paths-ignore: 
       - 'docs/**' 
       - '*.md'
-    branches:
-    - master
 
 # Environment variables available to all jobs and steps in this workflow
 env:
@@ -15,8 +13,8 @@ env:
   GKE_CLUSTER: github-ci
 
 jobs:
-  deploy-to-gke:
-    name: Deploy kCTF to GKE
+  build-and-deploy:
+    name: Build and deploy
     runs-on: ubuntu-latest
     steps:
 
@@ -79,7 +77,17 @@ jobs:
         echo PUBLIC=true | tee -a $(ls samples/*/chal.conf)
         echo HEALTHCHECK=true | tee -a $(ls samples/*/chal.conf)
 
+    - name: Build all tasks
+      run: |
+        cd samples
+        for f in *; do
+          if [ ! "$f" == "kctf-conf" ]; then
+            (cd $f && make docker)
+          fi
+        done
+
     - name: Deploy all tasks
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: |
         export PATH=$PATH:$PWD/bin
         kctf-batch-deploy

--- a/scripts/dev/docker.sh
+++ b/scripts/dev/docker.sh
@@ -35,4 +35,4 @@ VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')
 [ "$VERSION" == "master" ] && VERSION=latest
 
 docker tag $IMAGE $REPO:$VERSION
-[ "$PUSH" == "true"] && docker push $REPO:$VERSION
+[ "$PUSH" == "true" ] && docker push $REPO:$VERSION

--- a/scripts/dev/docker.sh
+++ b/scripts/dev/docker.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuo pipefail
 
 if [ "$#" -lt 3 ]; then
   echo "Illegal number of parameters"
@@ -6,6 +21,8 @@ if [ "$#" -lt 3 ]; then
   echo
   echo "For example: docker.sh pwntools gcr.io/kctf-docker/pwntools master true"
   echo "  That command will tag and push to GCR the local image pwntools."
+  echo "  If you ommit the last parameter (true), then the challenge won't be pushed."
+  exit 1
 fi
 
 IMAGE=$1
@@ -13,15 +30,9 @@ REPO=$2
 REF=$3
 PUSH=${4-false}
 
-# Strip git ref prefix from version
 VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')
-
-# Strip "v" prefix from tag name
 [[ "$REF" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-# Use Docker `latest` tag convention
 [ "$VERSION" == "master" ] && VERSION=latest
 
 docker tag $IMAGE $REPO:$VERSION
-
 [ "$PUSH" == "true"] && docker push $REPO:$VERSION

--- a/scripts/dev/docker.sh
+++ b/scripts/dev/docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "$#" -lt 3 ]; then
+  echo "Illegal number of parameters"
+  echo "Usage: docker.sh LOCAL_IMAGE REMOTE_IMAGE VERSION [PUSH]"
+  echo
+  echo "For example: docker.sh pwntools gcr.io/kctf-docker/pwntools master true"
+  echo "  That command will tag and push to GCR the local image pwntools."
+fi
+
+IMAGE=$1
+REPO=$2
+REF=$3
+PUSH=${4-false}
+
+# Strip git ref prefix from version
+VERSION=$(echo "$REF" | sed -e 's,.*/\(.*\),\1,')
+
+# Strip "v" prefix from tag name
+[[ "$REF" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+# Use Docker `latest` tag convention
+[ "$VERSION" == "master" ] && VERSION=latest
+
+docker tag $IMAGE $REPO:$VERSION
+
+[ "$PUSH" == "true"] && docker push $REPO:$VERSION


### PR DESCRIPTION
There is no way, currently, to test changes to the cached images on presubmit/postsubmit.

This change makes it possible by tagging locally-built images with their remote names.