### PR TITLE
Bypass the proof-of-work from the healthcheck

### DIFF
--- a/base/challenge-skeleton/challenge/config/nsjail.cfg
+++ b/base/challenge-skeleton/challenge/config/nsjail.cfg
@@ -38,6 +38,11 @@ mount: [
     src: "/config"
     dst: "/config"
     is_bind: true
+  },
+  {
+    src: "/pow-bypass"
+    dst: "/pow-bypass"
+    is_bind: true
   }
 ]
 

--- a/base/challenge-skeleton/healthcheck/exploit/doit.py
+++ b/base/challenge-skeleton/healthcheck/exploit/doit.py
@@ -19,7 +19,7 @@ import pwnlib
 def handle_pow(r):
     print(r.recvuntil('./pow.py solve '))
     challenge = r.recvline().strip()
-    p = pwnlib.tubes.process.process('bypass_pow.sh {}'.format(challenge))
+    p = pwnlib.tubes.process.process(['bypass_pow.sh', challenge])
     solution = p.readall().strip()
     r.sendline(solution)
     print(r.recvuntil('Correct\n'))

--- a/base/challenge-skeleton/healthcheck/exploit/doit.py
+++ b/base/challenge-skeleton/healthcheck/exploit/doit.py
@@ -14,6 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pwn import *
+import pwnlib
+
+def handle_pow(r):
+    r.recvuntil('./pow.py solve ')
+    challenge = r.recvline().strip()
+    proc = pwnlib.tubes.process.process('bypass_pow.sh')
+    solution = proc.readall().strip()
+    r.sendline(solution)
+    r.recvuntil('Correct\n')
+
+r = pwnlib.tubes.remote.remote('127.0.0.1', 1337)
+r.recvuntil('== proof-of-work: ')
+if r.recvline().startswith('enabled'):
+    handle_pow(r)
+
+r.sendline('cat /flag')
+r.recvuntil('CTF{')
+r.recvuntil('}')
 
 exit(0)

--- a/base/challenge-skeleton/healthcheck/exploit/doit.py
+++ b/base/challenge-skeleton/healthcheck/exploit/doit.py
@@ -17,20 +17,20 @@
 import pwnlib
 
 def handle_pow(r):
-    r.recvuntil('./pow.py solve ')
+    print(r.recvuntil('./pow.py solve '))
     challenge = r.recvline().strip()
-    proc = pwnlib.tubes.process.process('bypass_pow.sh')
-    solution = proc.readall().strip()
+    p = pwnlib.tubes.process.process('bypass_pow.sh {}'.format(challenge))
+    solution = p.readall().strip()
     r.sendline(solution)
-    r.recvuntil('Correct\n')
+    print(r.recvuntil('Correct\n'))
 
 r = pwnlib.tubes.remote.remote('127.0.0.1', 1337)
-r.recvuntil('== proof-of-work: ')
+print(r.recvuntil('== proof-of-work: '))
 if r.recvline().startswith('enabled'):
     handle_pow(r)
 
 r.sendline('cat /flag')
-r.recvuntil('CTF{')
-r.recvuntil('}')
+print(r.recvuntil('CTF{'))
+print(r.recvuntil('}'))
 
 exit(0)

--- a/base/challenge-skeleton/healthcheck/exploit/run.sh
+++ b/base/challenge-skeleton/healthcheck/exploit/run.sh
@@ -17,6 +17,9 @@ set -Eeuo pipefail
 TIMEOUT=20
 PERIOD=30
 
+export TERM=linux
+export TERMINFO=/etc/terminfo
+
 # Activate the pwntools venv
 PS1=""
 source /venv/bin/activate

--- a/base/challenge-skeleton/healthcheck/exploit/run.sh
+++ b/base/challenge-skeleton/healthcheck/exploit/run.sh
@@ -17,9 +17,6 @@ set -Eeuo pipefail
 TIMEOUT=20
 PERIOD=30
 
-export TERM=linux
-export TERMINFO=/etc/terminfo
-
 # Activate the pwntools venv
 PS1=""
 source /venv/bin/activate
@@ -27,7 +24,7 @@ source /venv/bin/activate
 while true; do
   source /config/env
   echo -n "[$(date)] "
-  if timeout "${TIMEOUT}" /exploit/doit.py NOTERM; then
+  if timeout "${TIMEOUT}" /exploit/doit.py; then
     echo 'ok' | tee /tmp/healthz
   else
     echo -n "$? "

--- a/base/healthcheck-docker/Dockerfile
+++ b/base/healthcheck-docker/Dockerfile
@@ -14,7 +14,7 @@
 FROM gcr.io/kctf-docker/kctf-pwntools:latest AS pwntools
 FROM ubuntu:19.10
 
-RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python2.7 && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 

--- a/base/healthcheck-docker/Dockerfile
+++ b/base/healthcheck-docker/Dockerfile
@@ -14,8 +14,7 @@
 FROM gcr.io/kctf-docker/kctf-pwntools:latest AS pwntools
 FROM ubuntu:19.10
 
-# needed by decrypt_exploit.sh
-RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python2.7 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 
@@ -23,3 +22,4 @@ COPY --from=pwntools /venv /venv
 RUN mkdir -p /home/user/.pwntools-cache && echo never > /home/user/.pwntools-cache/update
 
 COPY files/decrypt_exploit.sh /usr/bin/
+COPY files/bypass_pow.sh /usr/bin/

--- a/base/healthcheck-docker/files/bypass_pow.sh
+++ b/base/healthcheck-docker/files/bypass_pow.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CHALLENGE="$1"
+
+KEY="/pow-bypass/pow-bypass-key.pem"
+
+SIG=$(echo "${CHALLENGE}" | openssl dgst -SHA256 -hex -sign "${KEY}" - | awk '{print $2}')
+
+echo -n "b.${SIG}"

--- a/base/healthcheck-docker/files/bypass_pow.sh
+++ b/base/healthcheck-docker/files/bypass_pow.sh
@@ -4,6 +4,6 @@ CHALLENGE="$1"
 
 KEY="/pow-bypass/pow-bypass-key.pem"
 
-SIG=$(echo "${CHALLENGE}" | openssl dgst -SHA256 -hex -sign "${KEY}" - | awk '{print $2}')
+SIG=$(echo -n "${CHALLENGE}" | openssl dgst -SHA256 -hex -sign "${KEY}" - | awk '{print $2}')
 
 echo -n "b.${SIG}"

--- a/base/k8s/deployment-with-healthcheck/containers.yaml
+++ b/base/k8s/deployment-with-healthcheck/containers.yaml
@@ -53,6 +53,9 @@ spec:
         - name: "healthcheck-config"
           mountPath: "/config"
           readOnly: true
+        - name: "pow-bypass"
+          mountPath: "/pow-bypass"
+          readOnly: true
       volumes:
       - name: "healthcheck-secrets"
         secret:
@@ -65,3 +68,7 @@ spec:
       - name: "healthcheck-config"
         configMap:
           name: "healthcheck-config"
+      - name: "pow-bypass"
+        secret:
+          secretName: "pow-bypass"
+          defaultMode: 0444

--- a/base/k8s/deployment/containers.yaml
+++ b/base/k8s/deployment/containers.yaml
@@ -44,6 +44,9 @@ spec:
         - name: "config"
           mountPath: "/config"
           readOnly: true
+        - name: "pow-bypass-pub"
+          mountPath: "/pow-bypass"
+          readOnly: true
       volumes:
       - name: "secrets"
         secret:
@@ -52,3 +55,7 @@ spec:
       - name: "config"
         configMap:
           name: "config"
+      - name: "pow-bypass-pub"
+        secret:
+          secretName: "pow-bypass-pub"
+          defaultMode: 0444

--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -24,6 +24,12 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY --from=bin /usr/bin/nsjail /usr/bin/nsjail
 COPY --from=chroot /chroot /chroot
 
+# create a python3 venv and install ecdsa for the proof-of-work
+RUN apt-get update && apt-get -y install python3-venv
+RUN python3 -m venv /venv
+RUN bash -c "source /venv/bin/activate && pip3 install ecdsa"
+RUN mv /venv /chroot/
+
 RUN mkdir /chroot/config
 RUN mkdir /chroot/secrets
 

--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -32,6 +32,7 @@ RUN mv /venv /chroot/
 
 RUN mkdir /chroot/config
 RUN mkdir /chroot/secrets
+RUN mkdir /chroot/pow-bypass
 
 COPY files/k8s_nsjail_setup.sh /usr/bin/
 COPY files/proof_of_work/pow.py /chroot/usr/bin/

--- a/base/nsjail-docker/files/proof_of_work/maybe_pow.sh
+++ b/base/nsjail-docker/files/proof_of_work/maybe_pow.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 if [ -f /config/pow ]; then
+  source /venv/bin/activate
+
   POW="$(cat /config/pow)"
   if ! /usr/bin/pow.py ask "${POW}"; then
     echo 'pow fail'

--- a/base/nsjail-docker/files/proof_of_work/maybe_pow.sh
+++ b/base/nsjail-docker/files/proof_of_work/maybe_pow.sh
@@ -12,13 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 if [ -f /config/pow ]; then
   POW="$(cat /config/pow)"
-  if [ ${POW} != 0 ]; then
-    if ! /usr/bin/pow.py ask "${POW}"; then
-      echo 'pow fail'
-      exit 1
-    fi
+  if ! /usr/bin/pow.py ask "${POW}"; then
+    echo 'pow fail'
+    exit 1
   fi
 fi
 

--- a/base/nsjail-docker/files/proof_of_work/pow.py
+++ b/base/nsjail-docker/files/proof_of_work/pow.py
@@ -25,15 +25,6 @@ CHALSIZE = 2**128
 
 SOLVER_URL = 'https://github.com/google/kctf/blob/master/base/nsjail-docker/files/proof_of_work/pow.py'
 
-def stdin_is_localhost_socket():
-    try:
-        sock = socket.socket(fileno=sys.stdin.fileno())
-        peername = sock.getpeername()
-        sock.detach()
-        return peername[0] == '::ffff:127.0.0.1'
-    except OSError:
-        return False
-
 def sloth_root(x, diff, p):
     for i in range(diff):
         x = pow(x, (p + 1) // 4, p) ^ 1
@@ -96,8 +87,6 @@ def main():
             sys.stdout.write("== proof-of-work: disabled ==\n")
             sys.exit(0)
 
-        if stdin_is_localhost_socket():
-            sys.exit(0)
 
         challenge = get_challenge(difficulty)
 

--- a/base/nsjail-docker/files/proof_of_work/pow.py
+++ b/base/nsjail-docker/files/proof_of_work/pow.py
@@ -66,13 +66,10 @@ def solve_challenge(chal):
 def can_bypass(chal, sol):
     if not sol.startswith('b.'):
         return False
-    sig = sol[2:]
-    try:
-        with open("/pow-bypass/pow-bypass-key-pub.pem", "r") as fd:
-            vk = VerifyingKey.from_pem(fd.read())
-        return vk.verify(signature=sig, data=chal, hashfunc=hashlib.sha256, sigdecode=sigdecode_der)
-    except:
-        return False
+    sig = bytes.fromhex(sol[2:])
+    with open("/pow-bypass/pow-bypass-key-pub.pem", "r") as fd:
+        vk = VerifyingKey.from_pem(fd.read())
+    return vk.verify(signature=sig, data=bytes(chal, 'ascii'), hashfunc=hashlib.sha256, sigdecode=sigdecode_der)
 
 def verify_challenge(chal, sol):
     if can_bypass(chal, sol):

--- a/base/nsjail-docker/files/proof_of_work/pow.py
+++ b/base/nsjail-docker/files/proof_of_work/pow.py
@@ -120,7 +120,7 @@ def main():
             solution = sys.stdin.readline().strip()
 
         if verify_challenge(challenge, solution):
-            sys.stdout.write("Correct")
+            sys.stdout.write("Correct\n")
             sys.stdout.flush()
             sys.exit(0)
         else:

--- a/base/nsjail-docker/files/proof_of_work/pow.py
+++ b/base/nsjail-docker/files/proof_of_work/pow.py
@@ -93,6 +93,7 @@ def main():
         difficulty = int(sys.argv[2])
 
         if difficulty == 0:
+            sys.stdout.write("== proof-of-work: disabled ==\n")
             sys.exit(0)
 
         if stdin_is_localhost_socket():
@@ -100,7 +101,7 @@ def main():
 
         challenge = get_challenge(difficulty)
 
-        sys.stdout.write("== proof-of-work ==\n")
+        sys.stdout.write("== proof-of-work: enabled ==\n")
         sys.stdout.write("please solve a pow first\n")
         sys.stdout.write("You can find the solver at:\n")
         sys.stdout.write("  {}\n".format(SOLVER_URL))

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:19.10
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends debootstrap \
     && rm -rf /var/lib/apt/lists/* \
-    && debootstrap --variant minbase --include python3 eoan /chroot \
+    && debootstrap --variant minbase eoan /chroot \
     && echo nameserver 8.8.8.8 > /chroot/etc/resolv.conf \
     && chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user \
     && apt-get remove --purge -y debootstrap $(apt-mark showauto)

--- a/scripts/cluster/start.sh
+++ b/scripts/cluster/start.sh
@@ -70,13 +70,13 @@ fi
 
 gsutil acl ch -u "${GSA_EMAIL}:O" "gs://${BUCKET_NAME}"
 
-kubectl create configmap gcsfuse-config --from-literal=gcs_bucket="${BUCKET_NAME}" --namespace kube-system
+kubectl create configmap gcsfuse-config --from-literal=gcs_bucket="${BUCKET_NAME}" --namespace kube-system --dry-run -o yaml | kubectl apply -f -
 
-kubectl create -f "${DIR}/config/daemon-gcsfuse.yaml"
-kubectl create -f "${DIR}/config/apparmor.yaml"
-kubectl create -f "${DIR}/config/daemon.yaml"
-kubectl create -f "${DIR}/config/network-policy.yaml"
-kubectl create -f "${DIR}/config/allow-dns.yaml"
+kubectl apply -f "${DIR}/config/daemon-gcsfuse.yaml"
+kubectl apply -f "${DIR}/config/apparmor.yaml"
+kubectl apply -f "${DIR}/config/daemon.yaml"
+kubectl apply -f "${DIR}/config/network-policy.yaml"
+kubectl apply -f "${DIR}/config/allow-dns.yaml"
 kubectl patch ServiceAccount default --patch "automountServiceAccountToken: false"
 
 kubectl create secret generic pow-bypass --from-file="${CHAL_DIR}/kctf-conf/secrets/pow-bypass-key.pem" --dry-run -o yaml | kubectl apply -f -

--- a/scripts/cluster/start.sh
+++ b/scripts/cluster/start.sh
@@ -78,3 +78,6 @@ kubectl create -f "${DIR}/config/daemon.yaml"
 kubectl create -f "${DIR}/config/network-policy.yaml"
 kubectl create -f "${DIR}/config/allow-dns.yaml"
 kubectl patch ServiceAccount default --patch "automountServiceAccountToken: false"
+
+kubectl create secret generic pow-bypass --from-file="${CHAL_DIR}/kctf-conf/secrets/pow-bypass-key.pem" --dry-run -o yaml | kubectl apply -f -
+kubectl create secret generic pow-bypass-pub --from-file="${CHAL_DIR}/kctf-conf/secrets/pow-bypass-key-pub.pem" --dry-run -o yaml | kubectl apply -f -

--- a/scripts/setup/challenge-directory.sh
+++ b/scripts/setup/challenge-directory.sh
@@ -58,3 +58,10 @@ else
         rm "${CONFIG_DIR}/cluster.conf"
     fi
 fi
+
+# generate ecdsa keypair to be used for the proof-of-work bypass
+mkdir -p "${CHAL_DIR}/kctf-conf/secrets"
+pushd "${CHAL_DIR}/kctf-conf/secrets"
+openssl ecparam -name prime256v1 -genkey -noout -out pow-bypass-key.pem
+openssl ec -in pow-bypass-key.pem -pubout -out pow-bypass-key-pub.pem
+popd

--- a/scripts/setup/config-create.sh
+++ b/scripts/setup/config-create.sh
@@ -114,8 +114,12 @@ ln -fs "${CLUSTER_CONFIG}" "${CONFIG_FILE}"
 
 create_gcloud_config
 
-# there might be an existing cluster, try to get the creds
-if ! get_cluster_creds 2>/dev/null; then
+# there might be an existing cluster
+# if it already exists, we try to update it
+# otherwise, ask if we should start it
+if get_cluster_creds 2>/dev/null; then
+    "${DIR}/scripts/cluster/start.sh"
+else
     echo
     read -p "Start the cluster now (y/N)? " SHOULD_START
     echo


### PR DESCRIPTION
Use a per-CTF public/private key pair to sign pow requests.

Fixes #40 