### PR TITLE
Make registry configurable

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -27,6 +27,7 @@ SHELL := bash
 
 PUSH_TARGET="REMOTE"
 
+REGISTRY:=CONFIGMISSING
 PROJECT:=CONFIGMISSING
 CLUSTER_NAME:=CONFIGMISSING
 ZONE:=CONFIGMISSING
@@ -204,7 +205,7 @@ endif
 
 ${CLUSTER_GEN}/image-tagged: .gen/docker-image | .cluster-config
 	IMAGE_ID="$$(cat .gen/docker-image)"
-	IMAGE_TAG="eu.gcr.io/${PROJECT}/${CHALLENGE_NAME}:$${IMAGE_ID}"
+	IMAGE_TAG="${REGISTRY}/${PROJECT}/${CHALLENGE_NAME}:$${IMAGE_ID}"
 	docker tag "kctf-chal-${CHALLENGE_NAME}" "$${IMAGE_TAG}"
 	echo -n "$${IMAGE_TAG}" > $@
 
@@ -242,7 +243,7 @@ healthcheck/.gen/exploit.key: healthcheck/.gen/exploit.cpio
 
 ${CLUSTER_GEN}/healthcheck-image-tagged: .gen/healthcheck-docker-image | .cluster-config
 	IMAGE_ID="$$(cat .gen/healthcheck-docker-image)"
-	IMAGE_TAG="eu.gcr.io/${PROJECT}/${CHALLENGE_NAME}-healthcheck:$${IMAGE_ID}"
+	IMAGE_TAG="${REGISTRY}/${PROJECT}/${CHALLENGE_NAME}-healthcheck:$${IMAGE_ID}"
 	docker tag "kctf-healthcheck-${CHALLENGE_NAME}" "$${IMAGE_TAG}"
 	echo -n "$${IMAGE_TAG}" > $@
 

--- a/scripts/setup/config-create.sh
+++ b/scripts/setup/config-create.sh
@@ -21,6 +21,7 @@ mkdir -p "${CONFIG_DIR}"
 # Default Configuration
 
 CHAL_DIR=""
+REGISTRY="eu.gcr.io"
 PROJECT=""
 ZONE="europe-west4-b"
 CLUSTER_NAME="kctf-cluster"
@@ -37,6 +38,8 @@ function usage {
     echo -e "\t--project\tGoogle Cloud Platform project name" >&2
     echo -e "\t--zone\t\tGCP Zone (default: europe-west4-b)" >&2
     echo -e "\t\t\tFor a list of zones run: gcloud compute machine-types list --filter=\"name=( n2-standard-4 )\" --format 'value(zone)'" >&2
+    echo -e "\t--registry\t\tContainer Registry (default: eu.gcr.io)" >&2
+    echo -e "\t\t\tPossible values are us.gcr.io, asia.gcr.io, and eu.gcr.io" >&2
     echo -e "\t--cluster-name\tName of the kubernetes cluster (default: kctf-cluster)" >&2
     echo -e "\t--domain-name\tOptional domain name to host challenges under" >&2
     echo -e "\t--start-cluster\tStart the cluster if it's not running yet" >&2
@@ -63,6 +66,9 @@ while :; do
             ;;
         --zone)
             ZONE=$2
+            ;;
+        --registry)
+            REGISTRY=$2
             ;;
         --cluster-name)
             CLUSTER_NAME=$2
@@ -101,6 +107,7 @@ CLUSTER_CONFIG="${ret}"
 cat > "${CLUSTER_CONFIG}" << EOF
 PROJECT=${PROJECT}
 ZONE=${ZONE}
+REGISTRY=${REGISTRY}
 CLUSTER_NAME=${CLUSTER_NAME}
 DOMAIN_NAME=${DOMAIN_NAME}
 EOF


### PR DESCRIPTION
eu.gcr.io is still the default, but now you can pass it as a configuration value instead