### PR TITLE
Split long command

### DIFF
--- a/base/challenge-skeleton/challenge/image/Dockerfile
+++ b/base/challenge-skeleton/challenge/image/Dockerfile
@@ -17,4 +17,9 @@ COPY flag /chroot/
 COPY chal /chroot/home/user/
 COPY nsjail.cfg /home/user/
 
-CMD kctf_setup && drop_privs nsjail --config /kctf/nsjail_base.cfg --config /home/user/nsjail.cfg -- /usr/bin/stdbuf -i0 -o0 -e0 maybe_pow.sh /home/user/chal
+CMD kctf_setup && \
+    drop_privs \
+    nsjail --config /kctf/nsjail_base.cfg --config /home/user/nsjail.cfg -- \
+    /usr/bin/stdbuf -i0 -o0 -e0 \
+    maybe_pow.sh \
+    /home/user/chal


### PR DESCRIPTION
That said... maybe this should be:
```Dockerfile
CMD kctf_launch --drop_privs --stdbuf --nsjail /home/user/nsjail.cfg --pow \
    /home/user/chal
```
or..
```Dockerfile
CMD kctf_launch -p -w -b -j /home/user/nsjail.cfg /home/user/chal
```
or.. something like that