### PR TITLE
Revert "switch from SA key to workload identity to connect to GCS fuse"

### DIFF
--- a/config/daemon-gcsfuse.yaml
+++ b/config/daemon-gcsfuse.yaml
@@ -27,7 +27,6 @@ spec:
       labels:
         name: ctf-daemon-gcsfuse
     spec:
-      serviceAccountName: gcsfuse-sa
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
@@ -36,13 +35,15 @@ spec:
         image: ubuntu:19.10
         securityContext:
           privileged: true
-        command: ["sh", "-c", "apt-get update && apt-get install -y wget fuse && wget -q https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.29.0/gcsfuse_0.29.0_amd64.deb && dpkg -i gcsfuse_0.29.0_amd64.deb && mkdir -p /mnt/disks/gcs && ((test -f /config/gcs_bucket && gcsfuse --foreground --debug_fuse --debug_gcs --stat-cache-ttl 0 -type-cache-ttl 0 -o allow_other -o nonempty --file-mode 0777 --dir-mode 0777 --uid 1000 --gid 1000 $(cat /config/gcs_bucket) /mnt/disks/gcs))"]
+        command: ["sh", "-c", "apt-get update && apt-get install -y wget fuse && wget -q https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.29.0/gcsfuse_0.29.0_amd64.deb && dpkg -i gcsfuse_0.29.0_amd64.deb && mkdir -p /mnt/disks/gcs && ((test -f /config/gcs_bucket && gcsfuse --foreground --debug_fuse --debug_gcs --stat-cache-ttl 0 -type-cache-ttl 0 -o allow_other -o nonempty --file-mode 0777 --dir-mode 0777 --uid 1000 --gid 1000 --key-file=$(ls /secrets/*.json|head -n 1) $(cat /config/gcs_bucket) /mnt/disks/gcs))"]
         volumeMounts:
         - name: mnt-disks-gcs
           mountPath: /mnt/disks/gcs
           mountPropagation: Bidirectional
         - name: config
           mountPath: /config
+        - name: secrets
+          mountPath: /secrets
         lifecycle:
           preStop:
             exec:
@@ -54,3 +55,7 @@ spec:
       - name: config
         configMap:
           name: gcsfuse-config
+      - name: secrets
+        secret:
+          secretName: gcsfuse-secrets
+          defaultMode: 0444


### PR DESCRIPTION
Reverts google/kctf#75

See error:
https://github.com/google/kctf/runs/660654663?check_suite_focus=true#step:8:30

May be relevant
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity