### PR TITLE
For some reason `/dev/null` is no longer writeable (Read Only Filesystem Error)

### DIFF
--- a/samples/apache-others/challenge/image/chroot/node/run.sh
+++ b/samples/apache-others/challenge/image/chroot/node/run.sh
@@ -7,7 +7,7 @@ mkfifo /tmp/pipe
 node /home/user/chroot/node/app.js >/tmp/pipe &
 
 # This will wait for /tmp/pipe to be written to
-head -n 1 /tmp/pipe >/dev/null
+status=$(head -n 1 /tmp/pipe)
 
 # Proxy stdin/stdout to web server
 socat - TCP:127.0.0.1:8080


### PR DESCRIPTION
We need to supress output, so assigning to a variable instead.