### PR TITLE
pin python version to python3.8

### DIFF
--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/kctf-docker/kctf-nsjail-bin:latest AS bin
 FROM ubuntu:20.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
+    && apt-get install -yq --no-install-recommends python3.8 uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user

--- a/config/docker/chroot.Dockerfile
+++ b/config/docker/chroot.Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:20.04
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends debootstrap \
     && rm -rf /var/lib/apt/lists/* \
-    && debootstrap --include python3 --variant minbase focal /chroot \
+    && debootstrap --include python3.8 --variant minbase focal /chroot \
     && echo nameserver 8.8.8.8 > /chroot/etc/resolv.conf \
     && chroot /chroot /usr/sbin/useradd --no-create-home -u 1000 user \
     && apt-get remove --purge -y debootstrap $(apt-mark showauto)

--- a/samples/kctf-conf/base/nsjail-docker/Dockerfile
+++ b/samples/kctf-conf/base/nsjail-docker/Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/kctf-docker/kctf-nsjail-bin:latest AS bin
 FROM ubuntu:20.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
+    && apt-get install -yq --no-install-recommends python3.8 uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user


### PR DESCRIPTION
The python version of the chroot and the outer container need to be in sync so that our hack to copy the venv over works.
 
We should probably add a call to chroot /chroot sh -c "apt-get update && apt-get upgrade" to the nsjail docker file to always have the chroot up to date. Wdyt?