### PR TITLE
Always update chroot

### DIFF
--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -24,6 +24,8 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY --from=bin /usr/bin/nsjail /usr/bin/nsjail
 COPY --from=chroot /chroot /chroot
 
+RUN chroot /chroot sh -c 'apt-get update && apt-get -y upgrade'
+
 # create a python3 venv and install ecdsa for the proof-of-work
 RUN apt-get update && apt-get -y install python3-venv
 RUN python3 -m venv --copies /venv

--- a/samples/kctf-conf/base/nsjail-docker/Dockerfile
+++ b/samples/kctf-conf/base/nsjail-docker/Dockerfile
@@ -24,6 +24,8 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY --from=bin /usr/bin/nsjail /usr/bin/nsjail
 COPY --from=chroot /chroot /chroot
 
+RUN chroot /chroot sh -c 'apt-get update && apt-get -y upgrade'
+
 # create a python3 venv and install ecdsa for the proof-of-work
 RUN apt-get update && apt-get -y install python3-venv
 RUN python3 -m venv --copies /venv

--- a/scripts/cluster/start.sh
+++ b/scripts/cluster/start.sh
@@ -26,7 +26,7 @@ MACHINE_TYPE="n2-standard-4"
 EXISTING_CLUSTER=$(gcloud container clusters list --filter "name=${CLUSTER_NAME}" --format 'get(name)')
 
 if [ -z "${EXISTING_CLUSTER}" ]; then
-  gcloud container clusters create --enable-network-policy --enable-autoscaling --min-nodes ${MIN_NODES} --max-nodes ${MAX_NODES} --num-nodes ${NUM_NODES} --create-subnetwork name=kctf-${CLUSTER_NAME}-subnet --no-enable-master-authorized-networks --enable-ip-alias --enable-private-nodes --master-ipv4-cidr 172.16.0.32/28 --enable-autorepair --preemptible --machine-type ${MACHINE_TYPE} --workload-pool=${PROJECT}.svc.id.goog ${CLUSTER_NAME}
+  gcloud container clusters create --release-channel=regular --enable-network-policy --enable-autoscaling --min-nodes ${MIN_NODES} --max-nodes ${MAX_NODES} --num-nodes ${NUM_NODES} --create-subnetwork name=kctf-${CLUSTER_NAME}-subnet --no-enable-master-authorized-networks --enable-ip-alias --enable-private-nodes --master-ipv4-cidr 172.16.0.32/28 --enable-autorepair --preemptible --machine-type ${MACHINE_TYPE} --workload-pool=${PROJECT}.svc.id.goog ${CLUSTER_NAME}
 fi
 
 EXISTING_ROUTER=$(gcloud compute routers list --filter "name=kctf-${CLUSTER_NAME}-nat-router" --format 'get(name)')


### PR DESCRIPTION
Always update the chroot during nsjail build.

Once we have versioning, we will always use a particular version of the chroot.
On one hand this is undesirable since you will have an outdated user space (libc etc).
On the other hand, updating it might break long running challenges. For example a heap challenge being broken by new libc mitigations.

What do you think? I actually lean on not changing this atm :)