### PR TITLE
cluster-start: wait for operator readiness

### DIFF
--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator:v0.0.1
+          image: gcr.io/kctf-docker/kctf-operator:v0.0.2
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -32,3 +32,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "kctf-operator"
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /tmp/initialized
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/kctf-operator/pkg/resources/initializer.go
+++ b/kctf-operator/pkg/resources/initializer.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"os"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -45,6 +46,13 @@ func InitializeOperator(client *client.Client) error {
 			log.Info("Created object.", "Name:", names[i])
 		}
 	}
+
+	f, err := os.Create("/tmp/initialized")
+	if err != nil {
+		log.Error(err, "Could not create file for ReadinessProbe")
+		return err
+	}
+	f.Close()
 
 	return nil
 }

--- a/scripts/cluster/start.sh
+++ b/scripts/cluster/start.sh
@@ -62,7 +62,11 @@ kubectl apply -f "${DIR}/kctf-operator/deploy/crds/kctf.dev_challenges_crd.yaml"
 kubectl apply -f "${DIR}/kctf-operator/deploy/rbac.yaml"
 kubectl apply -f "${DIR}/kctf-operator/deploy/operator.yaml"
 
+# The operator needs to create some subresources, e.g. the gcsfuse service account
+kubectl wait --for=condition=available --namespace kube-system --timeout=5m deployment/kctf-operator
+
 GCS_KSA_NAME="gcsfuse-sa"
+
 
 gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${PROJECT}.svc.id.goog[kube-system/${GCS_KSA_NAME}]" ${GCS_GSA_EMAIL}
 kubectl annotate serviceaccount --namespace kube-system ${GCS_KSA_NAME} iam.gke.io/gcp-service-account=${GCS_GSA_EMAIL} --overwrite

--- a/scripts/cluster/start.sh
+++ b/scripts/cluster/start.sh
@@ -67,7 +67,6 @@ kubectl wait --for=condition=available --namespace kube-system --timeout=5m depl
 
 GCS_KSA_NAME="gcsfuse-sa"
 
-
 gcloud iam service-accounts add-iam-policy-binding --role roles/iam.workloadIdentityUser --member "serviceAccount:${PROJECT}.svc.id.goog[kube-system/${GCS_KSA_NAME}]" ${GCS_GSA_EMAIL}
 kubectl annotate serviceaccount --namespace kube-system ${GCS_KSA_NAME} iam.gke.io/gcp-service-account=${GCS_GSA_EMAIL} --overwrite
 


### PR DESCRIPTION
When starting a cluster, the kctf-operator will create a bunch of resources that we depend on later.
If we don't wait for those, the following commands will fail.