### PR TITLE
Fix apparmor and support updates

### DIFF
--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator:v0.0.2
+          image: gcr.io/kctf-docker/kctf-operator:v0.0.3
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/resources/apparmor.go
+++ b/kctf-operator/pkg/resources/apparmor.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewApparmorProfiles() runtime.Object {
-	ctfProfile := `|-
+	ctfProfile := `
     #include <tunables/global>
     profile ctf-profile flags=(attach_disconnected,mediate_deleted) {
       #include <abstractions/base>

--- a/kctf-operator/pkg/resources/initializer.go
+++ b/kctf-operator/pkg/resources/initializer.go
@@ -38,9 +38,13 @@ func InitializeOperator(client *client.Client) error {
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
 				log.Info("This object already exists.", "Name: ", names[i])
-			} else {
+				// Try to update the resource instead
+				err = (*client).Update(context.Background(), obj)
+			}
+			if err != nil {
 				log.Error(err, names[i])
 				log.Info(names[i])
+				return err
 			}
 		} else {
 			log.Info("Created object.", "Name:", names[i])


### PR DESCRIPTION
The apparmor profile had some spurious bytes at the beginning.
In addition, make the operator initialization update existing objects and bail out on any error.