### PR TITLE
Replace the chroot option with a bind mount in nsjail configs

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -190,7 +190,7 @@ jobs:
 
     - name: Commit
       run: |
-        MODIFIED_FILES="$(git status --porcelain | grep -v 'sample')"
+        MODIFIED_FILES="$(git status --porcelain | grep -v 'sample' || true)"
         echo "MODIFIED_FILES=${MODIFIED_FILES}"
         if [ ! -z "${MODIFIED_FILES}" ]; then
           git config user.email ${{ github.event.head_commit.author.email }}

--- a/base/challenge-skeleton/challenge/image/nsjail.cfg
+++ b/base/challenge-skeleton/challenge/image/nsjail.cfg
@@ -19,7 +19,6 @@ description: "Default nsjail configuration for pwnable-style CTF task."
 
 mode: LISTEN
 port: 1337
-chroot_dir: "/chroot"
 uidmap {inside_id: "1000"}
 gidmap {inside_id: "1000"}
 mount_proc: true

--- a/base/healthcheck-docker/Dockerfile
+++ b/base/healthcheck-docker/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/kctf-pwntools@sha256:520bb7f66b94e6c208c43fec9981d4f5f374247020a969dc04ae3e1ff1ba42b6 AS pwntools
+FROM gcr.io/kctf-docker/kctf-pwntools@sha256:3fcd0947ec18f84214963c9866a97d79bf76df018c4dbd12110818365cdfab98 AS pwntools
 FROM ubuntu:20.04
 
 RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python3 && rm -rf /var/lib/apt/lists/*

--- a/base/nsjail-docker/Dockerfile
+++ b/base/nsjail-docker/Dockerfile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/kctf-chroot@sha256:f83eb60015dcffa1965f9cefda67ed231ddd736d18885b33b144289311d6dc3b AS chroot
-FROM gcr.io/kctf-docker/kctf-nsjail@sha256:99e0fdd0fa3abcea927dc685dd665075eccb852ad806302e6ebc2be647b18008 AS bin
+FROM gcr.io/kctf-docker/kctf-chroot@sha256:53bc6fb257fd733d2fbd50db207e0dff2789dfb6e06ace8d35d202db1204eb5d AS chroot
+FROM gcr.io/kctf-docker/kctf-nsjail@sha256:d58591644115dc50585c1c649c8cc7574898863e6cf598a20675d3aa0e444e63 AS bin
 FROM ubuntu:20.04
 
 RUN apt-get update \

--- a/base/nsjail-docker/files/nsjail_base.cfg
+++ b/base/nsjail-docker/files/nsjail_base.cfg
@@ -1,11 +1,11 @@
 # Copyright 2020 Google LLC
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,11 @@ name: "kctf-base-config"
 description: "The base mounts required for kctf tools to work."
 
 mount: [
+  {
+    src: "/chroot"
+    dst: "/"
+    is_bind: true
+  },
   {
     src: "/kctf/pow-bypass"
     dst: "/.kctf/pow-bypass"

--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:a53308443ef7dc59992012e4e6b4a02a73e8fbb4f0ba8dea7e57f3e1dbfff2de
+          image: gcr.io/kctf-docker/kctf-operator@sha256:8a0024a8c5bfa593456340bf4306bcfe024ea24679d2c518c7bbcded4d4f5552
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/samples/apache-others/challenge/image/nsjail.cfg
+++ b/samples/apache-others/challenge/image/nsjail.cfg
@@ -18,7 +18,6 @@ name: "apache2-proxy-nsjail"
 description: "Example nsjail configuration for containing a web server."
 
 mode: LISTEN
-chroot_dir: "/chroot"
 uidmap {inside_id: "1000"}
 gidmap {inside_id: "1000"}
 mount_proc: true

--- a/samples/apache-php/challenge/image/root/nsjail-php.cfg
+++ b/samples/apache-php/challenge/image/root/nsjail-php.cfg
@@ -2,7 +2,6 @@ name: "php-cgi-nsjail-configuration"
 description: "PHP CGI nsjail configuration for web RCE CTF task."
 
 mode: ONCE
-chroot_dir: "/chroot"
 log_level: ERROR
 uidmap {inside_id: "1000"}
 mount_proc: true

--- a/samples/bash/challenge/image/nsjail.cfg
+++ b/samples/bash/challenge/image/nsjail.cfg
@@ -19,7 +19,6 @@ description: "Default nsjail configuration for pwnable-style CTF task."
 
 mode: LISTEN
 port: 1337
-chroot_dir: "/chroot"
 uidmap {inside_id: "1000"}
 gidmap {inside_id: "1000"}
 mount_proc: true


### PR DESCRIPTION
Nsjail removed the chroot option in july but for some reason it just started breaking my deployments.
Replace it with a bind mount (the recommended way by nsjail).