### PR TITLE
have operator try to become leader after initialization finished

### DIFF
--- a/kctf-operator/cmd/manager/main.go
+++ b/kctf-operator/cmd/manager/main.go
@@ -86,12 +86,6 @@ func main() {
 	}
 
 	ctx := context.TODO()
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "kctf-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
 
 	// Set default manager options
 	// Default manager watches all namespaces
@@ -143,6 +137,14 @@ func main() {
 	// which only happens when it is ran inside the cluster
 	if err := resources.InitializeOperator(&client); err != nil {
 		log.Error(err, "Error initializing initial instances")
+		os.Exit(1)
+	}
+
+	// Become the leader after initializtion is done
+	// Otherwise we're blocked on the readiness probe and the existing (outdated) operator won't terminate
+	err = leader.Become(ctx, "kctf-operator-lock")
+	if err != nil {
+		log.Error(err, "")
 		os.Exit(1)
 	}
 

--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:360c1db9d3b4cdaa75063cc8bc926e6970f8f84416c3e17af09483afea11b3c3
+          image: gcr.io/kctf-docker/kctf-operator@sha256:64285e826080f13e6067f85325ba51aa0afb1d27a046b6a978e4cfe2d06ba9ab
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/controller/challenge/status/functions.go
+++ b/kctf-operator/pkg/controller/challenge/status/functions.go
@@ -44,7 +44,7 @@ func Update(requeue bool, err error, challenge *kctfv1alpha1.Challenge, cl clien
 					challenge.Status.Status = pod.Status.Phase
 
 					// Then we update Health
-					if challenge.Spec.Healthcheck.Enabled == false {
+					if challenge.Spec.Healthcheck.Enabled == false || idx_challenge >= len(pod.Status.ContainerStatuses) {
 						challenge.Status.Health = "disabled"
 					} else {
 						// We check if the challenge is ready to know if it's healthy


### PR DESCRIPTION
Upgrading the operator with kubectl apply currently doesn't work:
* the old deployment is the leader
* the old deployment will only be terminated once the new deployment is marked ready
* the new deployment will run initializers after it became leader and run initializers

To fix this deadlock, I moved grabbing the leader lock to after the initialization is done.

To be merged after namespace_overhaul.