### PR TITLE
Allow challenge to challenge communication

### DIFF
--- a/kctf-operator/deploy/crds/kctf.dev_challenges_crd.yaml
+++ b/kctf-operator/deploy/crds/kctf.dev_challenges_crd.yaml
@@ -133,6 +133,11 @@ spec:
                 items:
                   type: string
                 type: array
+              allowConnectTo:
+                description: List of challenge names that this challenge is allowed to connect to
+                items:
+                  type: string
+                type: array
               podTemplate:
                 description: PodTemplate is used to set the template for the deployment's
                   pod, so that an author can add volumeMounts and other extra features

--- a/kctf-operator/deploy/operator.yaml
+++ b/kctf-operator/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:64285e826080f13e6067f85325ba51aa0afb1d27a046b6a978e4cfe2d06ba9ab
+          image: gcr.io/kctf-docker/kctf-operator@sha256:bc35c6ede41cd10e1ede71c96cbe9a399666cff504042ba5e5e4c13d1daf491e
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/go.sum
+++ b/kctf-operator/go.sum
@@ -1285,6 +1285,7 @@ k8s.io/apimachinery v0.16.13-rc.0/go.mod h1:4HMHS3mDHtVttspuuhrJ1GGr/0S9B6iWYWZ5
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.20.0 h1:jjzbTJRXk0unNS71L7h3lxGDH/2HPxMPaQY+MjECKL8=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.0.0-20200429005624-5127d3618e45/go.mod h1:4OxT/JnO1bObygTnRjqUGQqL8ytPJd7soYMeRdJchXw=

--- a/kctf-operator/pkg/apis/kctf/v1alpha1/challenge_types.go
+++ b/kctf-operator/pkg/apis/kctf/v1alpha1/challenge_types.go
@@ -106,6 +106,8 @@ type ChallengeSpec struct {
 
 	// Names of the desired PersistentVolumeClaims
 	PersistentVolumeClaims []string `json:"persistentVolumeClaims,omitempty"`
+
+	AllowConnectTo []string `json:"allowConnectTo,omitempty"`
 }
 
 // ChallengeStatus defines the observed state of Challenge

--- a/kctf-operator/pkg/apis/kctf/v1alpha1/zz_generated.deepcopy.go
+++ b/kctf-operator/pkg/apis/kctf/v1alpha1/zz_generated.deepcopy.go
@@ -95,6 +95,11 @@ func (in *ChallengeSpec) DeepCopyInto(out *ChallengeSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.AllowConnectTo != nil {
+		in, out := &in.AllowConnectTo, &out.AllowConnectTo
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/kctf-operator/pkg/controller/challenge/challenge_controller.go
+++ b/kctf-operator/pkg/controller/challenge/challenge_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/kctf/pkg/controller/challenge/autoscaling"
 	"github.com/google/kctf/pkg/controller/challenge/deployment"
 	"github.com/google/kctf/pkg/controller/challenge/dns"
+	"github.com/google/kctf/pkg/controller/challenge/network-policy"
 	"github.com/google/kctf/pkg/controller/challenge/pow"
 	"github.com/google/kctf/pkg/controller/challenge/secrets"
 	"github.com/google/kctf/pkg/controller/challenge/service"
@@ -152,7 +153,7 @@ func updateConfigurations(challenge *kctfv1alpha1.Challenge, cl client.Client, s
 	log logr.Logger, ctx context.Context) (bool, error) {
 	// We check if there's an error in each update
 	updateFunctions := []func(challenge *kctfv1alpha1.Challenge, client client.Client, scheme *runtime.Scheme,
-		log logr.Logger, ctx context.Context) (bool, error){volumes.Update,
+		log logr.Logger, ctx context.Context) (bool, error){network.Update, volumes.Update,
 		pow.Update, secrets.Update, deployment.Update, service.Update, dns.Update,
 		autoscaling.Update}
 

--- a/kctf-operator/pkg/controller/challenge/network-policy/functions.go
+++ b/kctf-operator/pkg/controller/challenge/network-policy/functions.go
@@ -1,0 +1,74 @@
+package network
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	kctfv1alpha1 "github.com/google/kctf/pkg/apis/kctf/v1alpha1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func isEqual(existingPolicy *netv1.NetworkPolicy, newPolicy *netv1.NetworkPolicy) bool {
+	return reflect.DeepEqual(existingPolicy.Spec, newPolicy.Spec)
+}
+
+func Update(challenge *kctfv1alpha1.Challenge, cl client.Client, scheme *runtime.Scheme,
+	log logr.Logger, ctx context.Context) (bool, error) {
+	requeue := false
+	var err error
+
+	for _, policy := range generatePolicies(challenge) {
+		requeue, err = updatePolicy(ctx, policy, challenge, cl, scheme, log)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return requeue, nil
+}
+
+func updatePolicy(ctx context.Context, policy netv1.NetworkPolicy, challenge *kctfv1alpha1.Challenge,
+	cl client.Client, scheme *runtime.Scheme, log logr.Logger) (bool, error) {
+	existingPolicy := &netv1.NetworkPolicy{}
+	err := cl.Get(ctx, types.NamespacedName{Name: policy.ObjectMeta.Name,
+		Namespace: policy.ObjectMeta.Namespace}, existingPolicy)
+
+	// Just enters here if it's a new policy
+	if err != nil && errors.IsNotFound(err) {
+		// Create a new object
+		controllerutil.SetControllerReference(challenge, &policy, scheme)
+		err = cl.Create(ctx, &policy)
+		if err != nil {
+			log.Error(err, "Failed to create Policy Name: ",
+				policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
+			return false, err
+		}
+		return true, nil
+	} else if err != nil {
+		log.Error(err, "Couldn't get the Policy Name: ",
+			policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
+		return false, err
+	}
+
+	if !isEqual(existingPolicy, &policy) {
+		existingPolicy.Spec = policy.Spec
+		err = cl.Update(ctx, existingPolicy)
+		if err != nil {
+			log.Error(err, "Failed to update Policy Name: ",
+				policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
+			return false, err
+		}
+
+		log.Info("Policy updated succesfully Name: ",
+			policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/kctf-operator/pkg/controller/challenge/network-policy/functions.go
+++ b/kctf-operator/pkg/controller/challenge/network-policy/functions.go
@@ -45,13 +45,13 @@ func updatePolicy(ctx context.Context, policy netv1.NetworkPolicy, challenge *kc
 		controllerutil.SetControllerReference(challenge, &policy, scheme)
 		err = cl.Create(ctx, &policy)
 		if err != nil {
-			log.Error(err, "Failed to create Policy Name: ",
+			log.Error(err, "Failed to create Policy", " Name: ",
 				policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
 			return false, err
 		}
 		return true, nil
 	} else if err != nil {
-		log.Error(err, "Couldn't get the Policy Name: ",
+		log.Error(err, "Couldn't get the Policy", " Name: ",
 			policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
 		return false, err
 	}
@@ -60,12 +60,12 @@ func updatePolicy(ctx context.Context, policy netv1.NetworkPolicy, challenge *kc
 		existingPolicy.Spec = policy.Spec
 		err = cl.Update(ctx, existingPolicy)
 		if err != nil {
-			log.Error(err, "Failed to update Policy Name: ",
+			log.Error(err, "Failed to update Policy", " Name: ",
 				policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
 			return false, err
 		}
 
-		log.Info("Policy updated succesfully Name: ",
+		log.Info("Policy updated succesfully", " Name: ",
 			policy.ObjectMeta.Name, " with namespace ", policy.ObjectMeta.Namespace)
 		return true, nil
 	}

--- a/kctf-operator/pkg/controller/challenge/network-policy/network-policy.go
+++ b/kctf-operator/pkg/controller/challenge/network-policy/network-policy.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"fmt"
+
+	kctfv1alpha1 "github.com/google/kctf/pkg/apis/kctf/v1alpha1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generatePolicies(challenge *kctfv1alpha1.Challenge) []netv1.NetworkPolicy {
+	var egressRules = make([]netv1.NetworkPolicyEgressRule, len(challenge.Spec.AllowConnectTo))
+	for i, targetName := range challenge.Spec.AllowConnectTo {
+		egressRules[i] = netv1.NetworkPolicyEgressRule{
+			To: []netv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": targetName,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	challengeAccessPolicy := netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v-challenge-access", challenge.Name),
+			Namespace: challenge.Namespace,
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PolicyTypes: []netv1.PolicyType{"Egress"},
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": challenge.Name,
+				},
+			},
+			Egress: egressRules,
+		},
+	}
+
+	return []netv1.NetworkPolicy{challengeAccessPolicy}
+}

--- a/kctf-operator/pkg/controller/challenge/service/service.go
+++ b/kctf-operator/pkg/controller/challenge/service/service.go
@@ -10,11 +10,35 @@ import (
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func generate(domainName string, challenge *kctfv1alpha1.Challenge) (*corev1.Service, *netv1beta1.Ingress) {
-	// Service object
+func generateClusterIPService(challenge *kctfv1alpha1.Challenge) *corev1.Service {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      challenge.Name,
+			Namespace: challenge.Namespace,
+			Labels:    map[string]string{"app": challenge.Name},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": challenge.Name},
+			Type:     "ClusterIP",
+			Ports:    make([]corev1.ServicePort, len(challenge.Spec.Network.Ports)),
+		},
+	}
+	for i, port := range challenge.Spec.Network.Ports {
+		service.Spec.Ports[i] = corev1.ServicePort{
+			Port:       port.TargetPort.IntVal,
+			TargetPort: port.TargetPort,
+			Protocol:   port.Protocol,
+		}
+	}
+
+	return service
+}
+
+func generateLoadBalancerService(domainName string, challenge *kctfv1alpha1.Challenge) (*corev1.Service, *netv1beta1.Ingress) {
+	// Service object
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      challenge.Name + "-lb-service",
 			Namespace: challenge.Namespace,
 			Labels:    map[string]string{"app": challenge.Name},
 		},
@@ -48,7 +72,7 @@ func generate(domainName string, challenge *kctfv1alpha1.Challenge) (*corev1.Ser
 
 			// Creates the ingress object
 			ingress.Spec.Backend = &netv1beta1.IngressBackend{
-				ServiceName: challenge.Name,
+				ServiceName: service.Name,
 				ServicePort: intstr.FromInt(int(port.Port)),
 			}
 

--- a/kctf-operator/pkg/controller/challenge/service/service.go
+++ b/kctf-operator/pkg/controller/challenge/service/service.go
@@ -20,15 +20,20 @@ func generateClusterIPService(challenge *kctfv1alpha1.Challenge) *corev1.Service
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{"app": challenge.Name},
 			Type:     "ClusterIP",
-			Ports:    make([]corev1.ServicePort, len(challenge.Spec.Network.Ports)),
+			Ports:    []corev1.ServicePort{},
 		},
 	}
-	for i, port := range challenge.Spec.Network.Ports {
-		service.Spec.Ports[i] = corev1.ServicePort{
+	for _, port := range challenge.Spec.Network.Ports {
+		protocol := corev1.ProtocolTCP
+		switch port.Protocol {
+		case corev1.ProtocolSCTP, corev1.ProtocolTCP, corev1.ProtocolUDP:
+			protocol = port.Protocol
+		}
+		service.Spec.Ports = append(service.Spec.Ports, corev1.ServicePort{
 			Port:       port.TargetPort.IntVal,
 			TargetPort: port.TargetPort,
-			Protocol:   port.Protocol,
-		}
+			Protocol:   protocol,
+		})
 	}
 
 	return service

--- a/kctf-operator/pkg/controller/challenge/status/functions.go
+++ b/kctf-operator/pkg/controller/challenge/status/functions.go
@@ -7,6 +7,7 @@ import (
 	kctfv1alpha1 "github.com/google/kctf/pkg/apis/kctf/v1alpha1"
 	utils "github.com/google/kctf/pkg/controller/challenge/utils"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -16,7 +17,8 @@ func Update(requeue bool, err error, challenge *kctfv1alpha1.Challenge, cl clien
 	pods := &corev1.PodList{}
 	var listOption client.ListOption
 	listOption = &client.ListOptions{
-		Namespace: challenge.Namespace,
+		Namespace:     challenge.Namespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{"app": challenge.Name}),
 	}
 
 	err_list := cl.List(ctx, pods, listOption)

--- a/kctf-operator/pkg/controller/challenge/volumes/functions.go
+++ b/kctf-operator/pkg/controller/challenge/volumes/functions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 	kctfv1alpha1 "github.com/google/kctf/pkg/apis/kctf/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,7 +103,8 @@ func Update(challenge *kctfv1alpha1.Challenge, cl client.Client, scheme *runtime
 	// List all persistent volume claims in the namespace of the challenge
 	var listOption client.ListOption
 	listOption = &client.ListOptions{
-		Namespace: challenge.Namespace,
+		Namespace:     challenge.Namespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{"app": challenge.Name}),
 	}
 
 	err := cl.List(ctx, persistentVolumeClaimsFound, listOption)

--- a/kctf-operator/pkg/controller/challenge/volumes/persistentvolumeclaim.go
+++ b/kctf-operator/pkg/controller/challenge/volumes/persistentvolumeclaim.go
@@ -19,6 +19,9 @@ func persistentVolumeClaim(claim string,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      claim,
 			Namespace: challenge.Namespace,
+			Labels: map[string]string{
+				"app": challenge.Name,
+			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			StorageClassName: &storageClassName,


### PR DESCRIPTION
Adds a new field to challenge.Spec: "allowConnectTo" where you can specify other challenges you can connect to
* creates a service for every deployment
* if allowConnectTo is specified, create a network policy that allows egress to pods of those challenges
* plus a bugfix since we deleted persistentvolume claims by accident when moving everything to the default namespace