### PR TITLE
Service/Ingress changes

### DIFF
--- a/dev/build-and-deploy-operator.sh
+++ b/dev/build-and-deploy-operator.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -Eeuo pipefail
+DIR="$( cd "$( dirname "$( readlink -f "${BASH_SOURCE[0]}")" )" >/dev/null && pwd )/.."
+
+if [[ -z "${PROJECT}" ]]; then
+  echo "you need to load a cluster config first (source kctf/activate)" >&2
+  exit 1
+fi
+
+# If there's a change in the CRD, we need to regenerate it and apply it to the cluster
+#export GOROOT=$(go env GOROOT)
+#operator-sdk generate k8s
+
+IMAGE_URL="${REGISTRY}/${PROJECT}/kctf-operator"
+echo "building image and pushing to ${IMAGE_URL}"
+
+cd "${DIR}/kctf-operator"
+
+operator-sdk build "${IMAGE_URL}"
+OPERATOR_SHA=$(docker push "${IMAGE_URL}" | egrep -o 'sha256:[0-9a-f]+' | head -n1)
+IMAGE_ID="${IMAGE_URL}@${OPERATOR_SHA}"
+echo "pushed to ${IMAGE_ID}"
+OPERATOR_YAML="${KCTF_CTF_DIR}/kctf/resources/operator.yaml"
+sed -i "s#image: .*#image: ${IMAGE_ID}#" "${OPERATOR_YAML}"
+"${KCTF_BIN}/bin/kctf-cluster" start

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -125,6 +125,13 @@ function kctf_cluster_start {
 }
 
 function kctf_cluster_stop {
+  echo "deleting all challenges so that load balancers etc can be cleaned up"
+  for chal_name in $(kubectl get challenges -o=jsonpath="{.items[*].metadata.name}"); do
+    kubectl delete "challenge/${chal_name}"
+  done
+  # deleting the cluster below takes a while, so sleeping for a bit doesn't hurt
+  sleep 20
+
   CLOUDSDK_CORE_DISABLE_PROMPTS=1 gcloud container clusters delete ${CLUSTER_NAME}
   gcloud compute routers delete "kctf-${CLUSTER_NAME}-nat-router" --region "${ZONE::-2}" --quiet
 

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -129,7 +129,9 @@ function kctf_cluster_stop {
   for chal_name in $(kubectl get challenges -o=jsonpath="{.items[*].metadata.name}"); do
     kubectl delete "challenge/${chal_name}"
   done
+
   # deleting the cluster below takes a while, so sleeping for a bit doesn't hurt
+  echo "Sleeping 20s to give time to delete resources" >&2
   sleep 20
 
   CLOUDSDK_CORE_DISABLE_PROMPTS=1 gcloud container clusters delete ${CLUSTER_NAME}

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:7dd9d043be73fe0634879958486b75e07ed1f7c0ee422f0aaa45e6a4627aaf21
+          image: gcr.io/kctf-docker/kctf-operator@sha256:8122a81314f14832c7b9fd21e0d52b9de15549c3e41d1164fe1956f07839c0ea
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/controller/challenge/set/default.go
+++ b/kctf-operator/pkg/controller/challenge/set/default.go
@@ -13,7 +13,7 @@ func portsDefault() []kctfv1alpha1.PortSpec {
 		kctfv1alpha1.PortSpec{
 			// Keeping the same name as in previous network file
 			Name:       "netcat",
-			Port:       1,
+			Port:       1337,
 			TargetPort: intstr.FromInt(1337),
 			Protocol:   "TCP",
 		},


### PR DESCRIPTION
A few changes related to services/ingresses:
* Use a NodePort service as the IngressBackend
* The NodePort service replaces the internal ClusterIP service
* Change ports to default 1337 and default port == targetPort
* Delete challenges before deleting the cluster to make sure that load balancers get cleaned up