### PR TITLE
Add support for "kind" clusters back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+dist/bin/kind
 dist/bin/yq
 dist/config/*

--- a/dist/activate
+++ b/dist/activate
@@ -15,6 +15,8 @@
 KCTF_YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64"
 KCTF_YQ_HASH="5d44bd64e264e9029c5f06bcd960ba162d7ed7ddd1781f02a28d62f50577b632"
 
+KIND_URL="https://kind.sigs.k8s.io/dl/v0.9.0/kind-$(uname)-amd64"
+
 export KCTF_CTF_DIR="$(realpath --no-symlinks "$(dirname "${BASH_SOURCE-$0}")/..")"
 
 function _kctf_setup_environment {
@@ -38,6 +40,11 @@ function _kctf_download_dependencies {
     wget "${KCTF_YQ_URL}" -O "${KCTF_BIN}/yq" --quiet || return 1
     sha256sum --status -c <(echo "${KCTF_YQ_HASH}  ${KCTF_BIN}/yq") || return 1
     chmod u+x "${KCTF_BIN}/yq"
+  fi
+
+  if [[ ! -x "${KCTF_BIN}/kind" ]]; then
+    curl -Lo "${KCTF_BIN}/kind" "${KIND_URL}" || return 1
+    chmod u+x "${KCTF_BIN}/kind"
   fi
 }
 

--- a/dist/activate
+++ b/dist/activate
@@ -104,6 +104,7 @@ function kctf {
           return 1
         fi
         source "${KCTF_CTF_DIR}/kctf/config/${CONFIG_NAME}"
+        export CLUSTER_TYPE
         export PROJECT
         export ZONE
         export REGISTRY
@@ -149,6 +150,7 @@ function _kctf_error_cleanup {
   unset KCTF_YQ_HASH
   unset KUBECONFIG
 
+  unset CLUSTER_TYPE
   unset PROJECT
   unset ZONE
   unset REGISTRY

--- a/dist/activate
+++ b/dist/activate
@@ -15,7 +15,8 @@
 KCTF_YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64"
 KCTF_YQ_HASH="5d44bd64e264e9029c5f06bcd960ba162d7ed7ddd1781f02a28d62f50577b632"
 
-KIND_URL="https://kind.sigs.k8s.io/dl/v0.9.0/kind-$(uname)-amd64"
+KCTF_KIND_URL="https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64"
+KCTF_KIND_HASH="35a640e0ca479192d86a51b6fd31c657403d2cf7338368d62223938771500dc8"
 
 export KCTF_CTF_DIR="$(realpath --no-symlinks "$(dirname "${BASH_SOURCE-$0}")/..")"
 
@@ -43,7 +44,8 @@ function _kctf_download_dependencies {
   fi
 
   if [[ ! -x "${KCTF_BIN}/kind" ]]; then
-    curl -Lo "${KCTF_BIN}/kind" "${KIND_URL}" || return 1
+    curl -Lo "${KCTF_BIN}/kind" "${KCTF_KIND_URL}" || return 1
+    sha256sum --status -c <(echo "${KCTF_KIND_HASH}  ${KCTF_BIN}/kind") || return 1
     chmod u+x "${KCTF_BIN}/kind"
   fi
 }

--- a/dist/bin/kctf-challenge
+++ b/dist/bin/kctf-challenge
@@ -143,36 +143,33 @@ function build_images {
 }
 
 function push_image {
-  IMAGE_BASE_URL=$1
+  IMAGE_NAME=$1
   IMAGE_ID=$2
 
-  #if the image id is a full URL, it has been already pushed
-  if [[ "${IMAGE_ID}" = "${IMAGE_BASE_URL}:"* ]]; then
-    IMAGE_URL="${IMAGE_ID}"
-  else
-    IMAGE_URL="${IMAGE_BASE_URL}:${IMAGE_ID}"
-    docker tag "${IMAGE_ID}" "${IMAGE_URL}" || return
-    case "${CLUSTER_TYPE}" in
-      gce)
-        docker push "${IMAGE_URL}" || return
-        ;;
-      kind)
-        "${KCTF_BIN}/kind" load docker-image --name "${CLUSTER_NAME}" "${IMAGE_URL}" || return
-        ;;
-      *)
-        echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
-        return 1
-        ;;
-    esac
-  fi
+  case "${CLUSTER_TYPE}" in
+    gce)
+      IMAGE_URL="${REGISTRY}/${PROJECT}/${CHALLENGE_NAME}-${IMAGE_NAME}:${IMAGE_ID}"
+      docker tag "${IMAGE_ID}" "${IMAGE_URL}" || return
+      docker push "${IMAGE_URL}" || return
+      ;;
+    kind)
+      IMAGE_URL="kind/${IMAGE_NAME}:${IMAGE_ID}"
+      docker tag "${IMAGE_ID}" "${IMAGE_URL}" || return
+      "${KCTF_BIN}/kind" load docker-image --name "${CLUSTER_NAME}" "${IMAGE_URL}" || return
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
   echo "Image pushed to \"${IMAGE_URL}\""
 }
 
 function push_images {
-  push_image "${REGISTRY}/${PROJECT}/${CHALLENGE_NAME}-challenge" "${CHALLENGE_IMAGE_LOCAL}" || return
+  push_image "challenge" "${CHALLENGE_IMAGE_LOCAL}" || return
   CHALLENGE_IMAGE_REMOTE="${IMAGE_URL}"
   if healthcheck_enabled; then
-    push_image "${REGISTRY}/${PROJECT}/${CHALLENGE_NAME}-healthcheck" "${HEALTHCHECK_IMAGE_LOCAL}" || return
+    push_image "healthcheck" "${HEALTHCHECK_IMAGE_LOCAL}" || return
     HEALTHCHECK_IMAGE_REMOTE="${IMAGE_URL}"
   fi
 }

--- a/dist/bin/kctf-challenge
+++ b/dist/bin/kctf-challenge
@@ -152,7 +152,18 @@ function push_image {
   else
     IMAGE_URL="${IMAGE_BASE_URL}:${IMAGE_ID}"
     docker tag "${IMAGE_ID}" "${IMAGE_URL}" || return
-    docker push "${IMAGE_URL}" || return
+    case "${CLUSTER_TYPE}" in
+      gce)
+        docker push "${IMAGE_URL}" || return
+        ;;
+      kind)
+        "${KCTF_BIN}/kind" load docker-image --name "${CLUSTER_NAME}" "${IMAGE_URL}" || return
+        ;;
+      *)
+        echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+        return 1
+        ;;
+    esac
   fi
   echo "Image pushed to \"${IMAGE_URL}\""
 }
@@ -179,6 +190,13 @@ function kctf_chal_start {
   fi
 
   kubectl apply -f "${CHALLENGE_DIR}/challenge.yaml" || return
+
+  if [[ "${CLUSTER_TYPE}" == "kind" ]]; then
+    # TODO: the operator should do this
+    # we should either have the operator know that it's running in kind (maybe add cluster_type in a configmap)
+    # or have an apparmor option in challenge.yaml
+    kubectl patch "deployment/${CHALLENGE_NAME}" --type json -p='[{"op": "remove", "path": "/spec/template/metadata/annotations/container.apparmor.security.beta.kubernetes.io~1challenge"}]'
+  fi
 }
 
 function kctf_chal_stop {

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -14,7 +14,27 @@
 # limitations under the License.
 set -Eeuo pipefail
 
-function kctf_cluster_start {
+function create_operator {
+  # Creating CRD, rbac and operator
+  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/kctf.dev_challenges_crd.yaml"
+  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/rbac.yaml"
+  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/operator.yaml"
+
+  OPERATOR_IMAGE=$("${KCTF_BIN}/yq" eval '.spec.template.spec.containers[0].image' "${KCTF_CTF_DIR}/kctf/resources/operator.yaml")
+
+  # The operator needs to create some subresources, e.g. the gcsfuse service account
+  for i in {1..30}; do
+    kubectl get pods --namespace kctf-system -o=jsonpath="{.items[*].status.containerStatuses[?(@.imageID==\"${OPERATOR_IMAGE}\")].ready}" | grep "true" && break
+    if [ "$i" == "30" ]; then
+      echo "Couldn't find a kctf-operator pod with status ready=true and image=\"${OPERATOR_IMAGE}\" after 5 minutes" >&2
+      kubectl get pods --namespace kctf-system -o=yaml >&2
+      exit 1
+    fi
+    sleep 10
+  done
+}
+
+function kctf_cluster_start_gce {
   MIN_NODES="1"
   MAX_NODES="2"
   NUM_NODES="1"
@@ -54,23 +74,7 @@ function kctf_cluster_start {
     done
   fi
 
-  # Creating CRD, rbac and operator
-  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/kctf.dev_challenges_crd.yaml"
-  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/rbac.yaml"
-  kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/operator.yaml"
-
-  OPERATOR_IMAGE=$("${KCTF_BIN}/yq" eval '.spec.template.spec.containers[0].image' "${KCTF_CTF_DIR}/kctf/resources/operator.yaml")
-
-  # The operator needs to create some subresources, e.g. the gcsfuse service account
-  for i in {1..30}; do
-    kubectl get pods --namespace kctf-system -o=jsonpath="{.items[*].status.containerStatuses[?(@.image==\"${OPERATOR_IMAGE}\")].ready}" | grep "true" && break
-    if [ "$i" == "30" ]; then
-      echo "Couldn't find a kctf-operator pod with status ready=true and image=\"${OPERATOR_IMAGE}\" after 5 minutes" >&2
-      kubectl get pods --namespace kctf-system -o=yaml >&2
-      exit 1
-    fi
-    sleep 10
-  done
+  create_operator
 
   GCS_KSA_NAME="gcsfuse-sa"
 
@@ -124,7 +128,24 @@ function kctf_cluster_start {
   fi
 }
 
-function kctf_cluster_stop {
+function kctf_cluster_start {
+  case "${CLUSTER_TYPE}" in
+    gce)
+      kctf_cluster_start_gce
+      return
+      ;;
+    kind)
+      kctf_cluster_start_kind
+      return
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
+}
+
+function kctf_cluster_stop_gce {
   echo "deleting all challenges so that load balancers etc can be cleaned up"
   for chal_name in $(kubectl get challenges -o=jsonpath="{.items[*].metadata.name}"); do
     kubectl delete "challenge/${chal_name}"
@@ -145,6 +166,39 @@ function kctf_cluster_stop {
   fi
 }
 
+function kctf_cluster_start_kind {
+  if ! "${KCTF_BIN}/kind" get kubeconfig --name "${CLUSTER_NAME}" >/dev/null 2>/dev/null; then
+    "${KCTF_BIN}/kind" create cluster --name "${CLUSTER_NAME}"
+  fi
+
+  kubectl create namespace "kctf-system" --dry-run=client -oyaml | kubectl apply -f - >&2
+
+  create_operator
+
+  kubectl patch ServiceAccount default --patch "automountServiceAccountToken: false"
+}
+
+function kctf_cluster_stop_kind {
+  "${KCTF_BIN}/kind" delete cluster --name "${CLUSTER_NAME}"
+}
+
+function kctf_cluster_stop {
+  case "${CLUSTER_TYPE}" in
+    gce)
+      kctf_cluster_stop_gce
+      return
+      ;;
+    kind)
+      kctf_cluster_stop_kind
+      return
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
+}
+
 function kctf_cluster_resize_usage {
   echo -e "usage: kctf cluster resize [args]" >&2
   echo -e "args:" >&2
@@ -159,6 +213,11 @@ function kctf_cluster_resize_usage {
 }
 
 function kctf_cluster_resize {
+  if [[ "${CLUSTER_TYPE}" != "gce" ]]; then
+    echo "only cluster type \"gce\" is supported by resize" >&2
+    return 1
+  fi
+
   OPTS="h"
   LONGOPTS="help,machine-type:,min-nodes:,max-nodes:,num-nodes:,pool-name:,old-pool"
   PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal create" -- "$@")

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -24,7 +24,7 @@ function create_operator {
 
   # The operator needs to create some subresources, e.g. the gcsfuse service account
   for i in {1..30}; do
-    kubectl get pods --namespace kctf-system -o=jsonpath="{.items[*].status.containerStatuses[?(@.imageID==\"${OPERATOR_IMAGE}\")].ready}" | grep "true" && break
+    kubectl get pods --namespace kctf-system -o=jsonpath="{.items[?(@.spec.containers[0].image==\"${OPERATOR_IMAGE}\")].status.containerStatuses[0].ready}" | grep "true" && break
     if [ "$i" == "30" ]; then
       echo "Couldn't find a kctf-operator pod with status ready=true and image=\"${OPERATOR_IMAGE}\" after 5 minutes" >&2
       kubectl get pods --namespace kctf-system -o=yaml >&2

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -23,14 +23,14 @@ function create_operator {
   OPERATOR_IMAGE=$("${KCTF_BIN}/yq" eval '.spec.template.spec.containers[0].image' "${KCTF_CTF_DIR}/kctf/resources/operator.yaml")
 
   # The operator needs to create some subresources, e.g. the gcsfuse service account
-  for i in {1..30}; do
+  for i in {1..100}; do
     kubectl get pods --namespace kctf-system -o=jsonpath="{.items[?(@.spec.containers[0].image==\"${OPERATOR_IMAGE}\")].status.containerStatuses[0].ready}" | grep "true" && break
-    if [ "$i" == "30" ]; then
+    if [ "$i" == "100" ]; then
       echo "Couldn't find a kctf-operator pod with status ready=true and image=\"${OPERATOR_IMAGE}\" after 5 minutes" >&2
       kubectl get pods --namespace kctf-system -o=yaml >&2
       exit 1
     fi
-    sleep 10
+    sleep 3
   done
 }
 

--- a/dist/bin/kctf-completion
+++ b/dist/bin/kctf-completion
@@ -123,6 +123,10 @@ function _kctf_complete_config() {
   case "${COMP_WORDS[2]}" in
     create)
       if [ "${PREV_IS_FLAG}" = 1 ] && [ "${PREV_WORD}" != "--start-cluster" ]; then
+        if [ "${PREV_WORD}" == "--type" ]; then
+          COMPREPLY=($(compgen -W "gce kind" -- "${COMP_WORDS[${COMP_CWORD}]}"))
+          return
+        fi
         if [ "${PREV_WORD}" == "--project" ]; then
           COMPREPLY=($(compgen -W "$(gcloud projects list --format 'get(project_id)')" -- "${COMP_WORDS[${COMP_CWORD}]}"))
           return
@@ -137,7 +141,7 @@ function _kctf_complete_config() {
         fi
         return 0
       fi
-      COMPREPLY=($(compgen -W "--help --project --zone --registry --cluster-name --domain-name --start-cluster" -- "${COMP_WORDS[${COMP_CWORD}]}"))
+      COMPREPLY=($(compgen -W "--help --type --project --zone --registry --cluster-name --domain-name --start-cluster" -- "${COMP_WORDS[${COMP_CWORD}]}"))
       return
       ;;
     load)

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -205,9 +205,6 @@ function kctf_config_create {
       fi
       ;;
     kind)
-      if [[ -z "$PROJECT" ]]; then
-        PROJECT="kind-project"
-      fi
       ;;
     *)
       echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -62,10 +62,23 @@ function kctf_config_load {
 
   source "${CONFIG_PATH}" || return 1
 
-  update_gcloud_config || return 1
-
-  # try to fetch the creds of the k8s cluster
-  gcloud container clusters get-credentials "${CLUSTER_NAME}" >/dev/null 2>/dev/null
+  case "${CLUSTER_TYPE}" in
+    gce)
+      update_gcloud_config || return 1
+      # try to fetch the creds of the k8s cluster
+      gcloud container clusters get-credentials "${CLUSTER_NAME}" >/dev/null 2>/dev/null
+      ;;
+    kind)
+      kube_config=$("${KCTF_BIN}/kind" get kubeconfig --name "${CLUSTER_NAME}" 2>/dev/null)
+      if [[ $? -eq 0 ]]; then
+        echo "${kube_config}" > "${KUBECONFIG}"
+      fi
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
 
   echo "loaded config" >&2
 
@@ -88,6 +101,8 @@ function kctf_config_list {
 function kctf_config_create_usage {
   echo -e "usage: kctf config create [args] config_name" >&2
   echo -e "  -h|--help       print this help" >&2
+  echo -e "  --type          what kind of cluster to create " >&2
+  echo -e "                  currently supported values: gce (remote) and kind (local)" >&2
   echo -e "  --project       Google Cloud Platform project name" >&2
   echo -e "  --zone          GCP Zone (default: europe-west4-b)" >&2
   echo -e "                  For a list of zones run:" >&2
@@ -101,6 +116,7 @@ function kctf_config_create_usage {
 
 function kctf_config_create {
   # Default Configuration
+  CLUSTER_TYPE="gce"
   REGISTRY="eu.gcr.io"
   PROJECT=""
   ZONE="europe-west4-b"
@@ -109,7 +125,7 @@ function kctf_config_create {
   START_CLUSTER="0"
 
   OPTS="h"
-  LONGOPTS="help,project:,zone:,registry:,cluster-name:,domain-name:,start-cluster"
+  LONGOPTS="help,type:,project:,zone:,registry:,cluster-name:,domain-name:,start-cluster"
   PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf config create" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_config_create_usage
@@ -122,6 +138,10 @@ function kctf_config_create {
       -h|--help)
         kctf_config_create_usage
         return 1
+        ;;
+      --type)
+        CLUSTER_TYPE=$2
+        shift 2
         ;;
       --project)
         PROJECT=$2
@@ -176,11 +196,24 @@ function kctf_config_create {
   CONFIG_PATH="${KCTF_CTF_DIR}/kctf/config/${CONFIG_NAME}"
   shift
 
-  if [[ -z "$PROJECT" ]]; then
-    echo "Missing required argument \"--project\"." >&2
-    kctf_config_create_usage
-    return 1
-  fi
+  case "${CLUSTER_TYPE}" in
+    gce)
+      if [[ -z "$PROJECT" ]]; then
+        echo "Missing required argument \"--project\"." >&2
+        kctf_config_create_usage
+        return 1
+      fi
+      ;;
+    kind)
+      if [[ -z "$PROJECT" ]]; then
+        PROJECT="kind-project"
+      fi
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
 
   mkdir -p "${KCTF_CTF_DIR}/kctf/config"
 
@@ -191,6 +224,7 @@ function kctf_config_create {
   fi
 
   cat > "${CONFIG_PATH}" << EOF
+CLUSTER_TYPE=${CLUSTER_TYPE}
 PROJECT=${PROJECT}
 ZONE=${ZONE}
 REGISTRY=${REGISTRY}
@@ -198,12 +232,29 @@ CLUSTER_NAME=${CLUSTER_NAME}
 DOMAIN_NAME=${DOMAIN_NAME}
 EOF
 
-  update_gcloud_config || return 1
+  case "${CLUSTER_TYPE}" in
+    gce)
+      update_gcloud_config || return 1
+      # try to fetch the creds of the k8s cluster
+      gcloud container clusters get-credentials "${CLUSTER_NAME}" >/dev/null 2>/dev/null
+      GET_CLUSTER_CREDS_RESULT=$?
+      ;;
+    kind)
+      kube_config=$("${KCTF_BIN}/kind" get kubeconfig --name "${CLUSTER_NAME}" 2>/dev/null)
+      GET_CLUSTER_CREDS_RESULT=$?
+      if [[ "${GET_CLUSTER_CREDS_RESULT}" -eq 0 ]]; then
+        echo "${kube_config}" > "${KUBECONFIG}"
+      fi
+      ;;
+    *)
+      echo "unknown cluster type \"${CLUSTER_TYPE}\"" >&2
+      return 1
+      ;;
+  esac
 
   # there might be an existing cluster
   # if it already exists, we try to update it
-  # otherwise, start it if requsted
-  gcloud container clusters get-credentials "${CLUSTER_NAME}" >/dev/null 2>/dev/null
+  # otherwise, start it if requested
   GET_CLUSTER_CREDS_RESULT=$?
   if [[ "${START_CLUSTER}" == "1" ]] || [[ ${GET_CLUSTER_CREDS_RESULT} -eq 0 ]]; then
     if [[ ${GET_CLUSTER_CREDS_RESULT} -eq 0 ]]; then
@@ -211,6 +262,7 @@ EOF
     else
       echo "Starting cluster." >&2
     fi
+    export CLUSTER_TYPE
     export PROJECT
     export ZONE
     export REGISTRY


### PR DESCRIPTION
You can now create a --type "kind" cluster with `kctf config create` and then use it as usual.
I.e. just run `kctf chal start` and it will deploy to the local cluster.

The apparmor handling is copied from how it worked before, but it's racy since the deployment might not have been created yet.
I'm thinking of exposing an apparmor option in the challenge.yaml to control this.
Wdyt?