### PR TITLE
Fix bash escaping error and missing git add

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -141,13 +141,13 @@ jobs:
       if: needs.build-docker.outputs.gcsfuse-modified
       run: |
         IMAGE="gcr.io/kctf-docker/gcsfuse@${{ needs.build-docker.outputs.gcsfuse-digest }}"
-        sed -i 's%const DOCKER_GCSFUSE_IMAGE = .*%const DOCKER_GCSFUSE_IMAGE = "${IMAGE}"%' kctf-operator/pkg/resources/constants.go
+        sed -i 's%const DOCKER_GCSFUSE_IMAGE = .*%const DOCKER_GCSFUSE_IMAGE = "'${IMAGE}'"%' kctf-operator/pkg/resources/constants.go
 
     - name: Update certbot image
       if: needs.build-docker.outputs.certbot-modified
       run: |
         IMAGE="gcr.io/kctf-docker/certbot@${{ needs.build-docker.outputs.certbot-digest }}"
-        sed -i 's%const DOCKER_CERTBOT_IMAGE = .*%const DOCKER_CERTBOT_IMAGE = "${IMAGE}"%' kctf-operator/pkg/resources/constants.go
+        sed -i 's%const DOCKER_CERTBOT_IMAGE = .*%const DOCKER_CERTBOT_IMAGE = "'${IMAGE}'"%' kctf-operator/pkg/resources/constants.go
 
     - name: Update operator
       if: needs.build-docker.outputs.kctf-operator-modified

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -215,6 +215,7 @@ jobs:
     - name: Commit
       run: |
         # git add returns success for files that exist and haven't been modified
+        git add kctf-operator/pkg/resources/constants.go
         git add dist/resources/operator.yaml
         for dir in dist/challenge-templates/* samples/*; do
           if [[ ! -e "${dir}/challenge.yaml" ]]; then
@@ -226,7 +227,7 @@ jobs:
         done
         git status
         git config user.email ${{ github.event.head_commit.author.email }}
-        git config user.name ${{ github.event.head_commit.author.name }}
+        git config user.name "GitHub Action"
         if git commit -m "Automated commit: update images."; then
           git push
         fi

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -26,7 +26,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY --from=build /build/chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
+FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -26,7 +26,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY --from=build /build/chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:b2a1adddbe60a7bce7c4ee94361ae0c9b7367a459570ccccdb87743effb1c971
+FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:0083098197546a83c1ee975574c3479a6f3087d08f99f74dc92db8c5be7795ea
+FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
+FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 
 RUN mkdir -p /home/user/chroot
 
-FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
+FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 
 RUN mkdir -p /home/user/chroot
 
-FROM gcr.io/kctf-docker/challenge@sha256:b2a1adddbe60a7bce7c4ee94361ae0c9b7367a459570ccccdb87743effb1c971
+FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:0083098197546a83c1ee975574c3479a6f3087d08f99f74dc92db8c5be7795ea
+FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
+FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
+FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:b2a1adddbe60a7bce7c4ee94361ae0c9b7367a459570ccccdb87743effb1c971
+FROM gcr.io/kctf-docker/challenge@sha256:56954dbdf2a0c6b2d288734afea2ae5a36a91a0e28a037d84bc883eb3c7cf0d0
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:0083098197546a83c1ee975574c3479a6f3087d08f99f74dc92db8c5be7795ea
+FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:d436765c4d7d18c4aef022509b8a1da6d8a2544149df5a3ff09f840e86f50ae6
+FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:fa19cf3ee6ff356d60beee45c15951bce473594ed3037fca7cf22d9ff6457702
+          image: gcr.io/kctf-docker/kctf-operator@sha256:cfa8df408954baa58f53595624e04af53660ef47f961dfe1c37369bb9d9b0445
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:cfa8df408954baa58f53595624e04af53660ef47f961dfe1c37369bb9d9b0445
+          image: gcr.io/kctf-docker/kctf-operator@sha256:a2dc4b0a16c0a1accf9bf365729ef99ab54dc6d29f10713fc376d69b0569d95b
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,8 +5,8 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "${IMAGE}"
-const DOCKER_GCSFUSE_IMAGE = "${IMAGE}"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:70ebd727290c2ca161743f6080ec53178d6f079f5625dbe6db6fc8e4d3272138"
+const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:3bc4ee2b5f902f4545bddd1afa70276a95bc9bdebe1d986e57ed1ea8f6ec4d84"
 
 // .. ^^ ........................... ^^ ..
 // == || These are set by automation || ==

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,8 +5,8 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "eu.gcr.io/sdcpocs1/certbot@sha256:620f0f4430e8b4f596578759c55ba0d7fee66fbe5f00a7e90b9b707afa231922"
-const DOCKER_GCSFUSE_IMAGE = "eu.gcr.io/sdcpocs1/gcsfuse@sha256:f91aac6fec8cb273610ca497747f131cb4ca23d6de50b12f761f98564e41e639"
+const DOCKER_CERTBOT_IMAGE = "${IMAGE}"
+const DOCKER_GCSFUSE_IMAGE = "${IMAGE}"
 
 // .. ^^ ........................... ^^ ..
 // == || These are set by automation || ==


### PR DESCRIPTION
My name has double and single quotes, and I don't think we can easily escape it.

Changing the name of the author, which anyway is better because that way it's more obvious which commit is automated.

Also adding a missing `git add`