### PR TITLE
Replace prod certs to test if needed

### DIFF
--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: kctf-operator
           # TODO: Replace this with the built image name
-          image: gcr.io/kctf-docker/kctf-operator@sha256:a2dc4b0a16c0a1accf9bf365729ef99ab54dc6d29f10713fc376d69b0569d95b
+          image: gcr.io/kctf-docker/kctf-operator@sha256:44cfca0b6e86e0b0bd365e7a5618f66b4403288b90c5901c13dd9bef23b93ba7
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/docker-images/certbot/certbot.sh
+++ b/docker-images/certbot/certbot.sh
@@ -21,7 +21,7 @@ if [ -z "${PROD}" ]; then
   echo Making a test certificate because PROD environment variable is not set.
 else
   echo Making a valid certificate because PROD environment variable is set.
-  TEST=""
+  TEST="--break-my-certs"
 fi
 
 function request_certificate() {

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,7 +5,7 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:70ebd727290c2ca161743f6080ec53178d6f079f5625dbe6db6fc8e4d3272138"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:3b765f36c11c425931f38a9e71ea1dd8309dca1d5fac86fd2fda50800382d4d9"
 const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:3bc4ee2b5f902f4545bddd1afa70276a95bc9bdebe1d986e57ed1ea8f6ec4d84"
 
 // .. ^^ ........................... ^^ ..


### PR DESCRIPTION
from certbot docs:
```
  --break-my-certs      Be willing to replace or renew valid certificates with
                        invalid (testing/staging) certificates (default:
                        False)
```

this is apparently needed also for the other direction (test->prod). _might be a bug in certbot_