### PR TITLE
Pass better flags to certbot

### DIFF
--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:06fe29bd3534ee649e7dfcd0a2a83874142c1f42a41ce1d2e08bd9d7034c6ed4
+          image: gcr.io/kctf-docker/kctf-operator@sha256:f332cc59dd3e43a9efd04658470823eacfdf29ab077ce81cba2bec536e438d48
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/docker-images/certbot/certbot.sh
+++ b/docker-images/certbot/certbot.sh
@@ -1,31 +1,32 @@
 #!/bin/bash
 
-TEST="--test-cert"
-
 if [ -z "${DOMAIN}" ]; then
-  echo Make sure the DOMAIN environment variable points to the domain.
-  exit 1
-fi
-
-if [ -z "${EMAIL}" ]; then
-  echo Make sure the EMAIL environment variable points to the email.
+  echo "Make sure the DOMAIN environment variable points to the domain."
   exit 1
 fi
 
 if [ -z "${SECRET}" ]; then
-  echo Make sure the SECRET environment variable points to the k8s secret.
+  echo "Make sure the SECRET environment variable points to the k8s secret."
   exit 1
 fi
 
 if [ -z "${PROD}" ]; then
-  echo Making a test certificate because PROD environment variable is not set.
+  echo "Making a TEST certificate because PROD environment variable is NOT set."
+  TEST="--test-cert"
 else
-  echo Making a valid certificate because PROD environment variable is set.
-  TEST="--break-my-certs"
+  echo "Making a REAL certificate because PROD environment variable is set."
+  TEST=""
+fi
+
+if [ -z "${EMAIL}" ]; then
+  echo "Registering certificate unsafely without email. Pass an EMAIL to register an account with an email address."
+  EMAIL_FLAG="--register-unsafely-without-email"
+else
+  EMAIL_FLAG="-m ${EMAIL}"
 fi
 
 function request_certificate() {
-  certbot certonly "${TEST}" --non-interactive --agree-tos -m "${EMAIL}" --dns-google -d '*.'"${DOMAIN}" --dns-google-propagation-seconds 120
+  certbot certonly ${TEST} --non-interactive --agree-tos ${EMAIL_FLAG} --dns-google -d '*.'"${DOMAIN}" --dns-google-propagation-seconds 120
 }
 
 function update_tls_secret() {
@@ -37,12 +38,12 @@ function check_tls_validity() {
 }
 
 while true; do
-  echo Waiting 2 minutes to avoid hitting rate limits
+  echo "Waiting 2 minutes to avoid hitting rate limits"
   sleep 2m
   if check_tls_validity; then
-    echo Certificate is valid for at least 30 days
+    echo "Certificate is valid for at least 30 days"
     sleep 1d
   else
-    request_certificate && update_tls_secret && echo TLS cert updated
+    request_certificate && update_tls_secret && echo "TLS cert updated"
   fi
 done

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,7 +5,7 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:3b765f36c11c425931f38a9e71ea1dd8309dca1d5fac86fd2fda50800382d4d9"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:4b92089f67635182d4754071d25eb1048ccae097b88dca9aab00676bef511db8"
 const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:3bc4ee2b5f902f4545bddd1afa70276a95bc9bdebe1d986e57ed1ea8f6ec4d84"
 
 // .. ^^ ........................... ^^ ..


### PR DESCRIPTION
This changes 3 things:
 1. Remove `--break-my-certs`. This was failing for a different reason than I thought (turns out it was the quotes around `"${TEST}"`...)
 2. Allow registering for a wildcard cert without an email. Since we still always use `ManagedCertificate`, this sounds fine if things break (eg, client-incompatible changes). Fixes #211 
 3. Reorder ifs a little bit to make required flags on top, and optional ones below.