### PR TITLE
Support automatic domains via kctf.cloud

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -177,7 +177,7 @@ jobs:
         mkdir /tmp/samples
         cp -R dist /tmp/samples/kctf
         source /tmp/samples/kctf/activate
-        kctf config create --project $GKE_PROJECT --zone $GKE_ZONE --registry $GKE_REGISTRY --cluster-name $GKE_CLUSTER --domain-name $GKE_CLUSTER.kctf.dev --start-cluster test
+        kctf config create --project $GKE_PROJECT --zone $GKE_ZONE --registry $GKE_REGISTRY --cluster-name $GKE_CLUSTER --domain-name kctf-ci.kctf.cloud --start-cluster test
 
     - name: Deploy all tasks
       run: |

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -131,7 +131,29 @@ function kctf_cluster_start_gce {
 
     DNS_ZONE=$(gcloud dns managed-zones list --filter "name:${ZONE_NAME}" --format 'get(name)')
     if [ -z "${DNS_ZONE}" ]; then
+      _kctf_log "creating new managed-zone \"${ZONE_NAME}\""
       gcloud dns managed-zones create "${ZONE_NAME}" --description "DNS Zone for ${DOMAIN_NAME}" --dns-name="${DOMAIN_NAME}."
+      soa_ttl="$(gcloud dns record-sets list --zone=${ZONE_NAME} --type=SOA --name="${DOMAIN_NAME}." --format='get(ttl)')"
+      soa_data="$(gcloud dns record-sets list --zone=${ZONE_NAME} --type=SOA --name="${DOMAIN_NAME}." --format='get(DATA)')"
+      new_soa=($soa_data)
+      # update the serial no
+      new_soa[2]=$((${new_soa[2]} + 1))
+      # change the ttl
+      new_soa[6]="60"
+
+      _kctf_log "changing the SOA entry to reduce TTL"
+      gcloud dns record-sets transaction start --zone="${ZONE_NAME}"
+      gcloud dns record-sets transaction remove --zone="${ZONE_NAME}" --name "${DOMAIN_NAME}." --ttl "${soa_ttl}" --type "SOA" "${soa_data}"
+      gcloud dns record-sets transaction add --zone="${ZONE_NAME}" --name "${DOMAIN_NAME}." --ttl "60" --type "SOA" "${new_soa[*]}"
+      gcloud dns record-sets transaction describe --zone="${ZONE_NAME}"
+      if ! gcloud dns record-sets transaction execute --zone="${ZONE_NAME}"; then
+        gcloud dns record-sets transaction abort --zone="${ZONE_NAME}"
+        _kctf_log_err 'updating the SOA entry failed'
+        exit 1
+      fi
+      _kctf_log "SOA updated"
+    else
+      _kctf_log "managed-zone \"${ZONE_NAME}\" exists, reusing"
     fi
 
     DNS_ZONE_NAMESERVERS=$(gcloud dns managed-zones describe "${ZONE_NAME}" --format 'value[delimiter="\n"](nameServers)')

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -42,7 +42,7 @@ function create_operator {
 
 function wait_for_nameserver {
   nameserver="$1"
-  initial_timeout=180
+  initial_timeout=300
   timeout=$initial_timeout
   sleep_time=10
   while [[ "${timeout}" -gt 0 ]]; do

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -16,7 +16,7 @@ set -Eeuo pipefail
 
 source "${KCTF_BIN}/kctf-log"
 
-KCTF_CLOUD_BASE_URL="https://kctf-cloud.appspot.com"
+KCTF_CLOUD_BASE_URL="https://kctf-cloud.appspot.com/v1"
 KCTF_CLOUD_API_KEY="AIzaSyC7Jgu4e0IygmImZNPmJHrcfZ3lJA9ZrZs"
 
 function create_operator {

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -105,11 +105,16 @@ function kctf_cluster_start_gce {
 
   # Cloud DNS
 
-  if [ ! -z "${DOMAIN_NAME}" ]
-  then
+  if [ ! -z "${DOMAIN_NAME}" ]; then
     DNS_ZONE=$(gcloud dns managed-zones list --filter "dns_name:${DOMAIN_NAME}" --format 'get(name)')
     if [ -z "${DNS_ZONE}" ]; then
-      gcloud dns managed-zones create "${CLUSTER_NAME}-dns-zone" --description "DNS Zone for ${DOMAIN_NAME}" --dns-name="${DOMAIN_NAME}."
+      ZONE_NAME="${CLUSTER_NAME}-dns-zone"
+      if [ ! -z "$(gcloud dns managed-zones list --filter "name:${ZONE_NAME}" --format 'get(name)')" ]; then
+        _kctf_log "Conflicting dns managed-zone found. Deleting before recreating it."
+        gcloud dns managed-zones delete "${ZONE_NAME}"
+      fi
+      gcloud dns managed-zones create "${ZONE_NAME}" --description "DNS Zone for ${DOMAIN_NAME}" --dns-name="${DOMAIN_NAME}."
+    fi
     fi
 
     DNS_GSA_NAME="kctf-cloud-dns"

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -126,17 +126,14 @@ function kctf_cluster_start_gce {
   # Cloud DNS
 
   if [ ! -z "${DOMAIN_NAME}" ]; then
-    DNS_ZONE=$(gcloud dns managed-zones list --filter "dns_name:${DOMAIN_NAME}" --format 'get(name)')
+    ZONE_NAME="$(echo ${DOMAIN_NAME} | sed 's/[.]/--/g')-dns-zone"
+
+    DNS_ZONE=$(gcloud dns managed-zones list --filter "name:${ZONE_NAME}" --format 'get(name)')
     if [ -z "${DNS_ZONE}" ]; then
-      ZONE_NAME="${CLUSTER_NAME}-dns-zone"
-      if [ ! -z "$(gcloud dns managed-zones list --filter "name:${ZONE_NAME}" --format 'get(name)')" ]; then
-        _kctf_log "Conflicting dns managed-zone found. Deleting before recreating it."
-        gcloud dns managed-zones delete "${ZONE_NAME}"
-      fi
       gcloud dns managed-zones create "${ZONE_NAME}" --description "DNS Zone for ${DOMAIN_NAME}" --dns-name="${DOMAIN_NAME}."
     fi
 
-    DNS_ZONE_NAMESERVERS=$(gcloud dns managed-zones describe kctf-cluster-dns-zone --format 'value[delimiter="\n"](nameServers)')
+    DNS_ZONE_NAMESERVERS=$(gcloud dns managed-zones describe "${ZONE_NAME}" --format 'value[delimiter="\n"](nameServers)')
     if [[ "${DOMAIN_NAME}" == *".kctf.cloud" ]]; then
       _kctf_log "waiting for nameservers to be updated (should take roughly 1m)"
       for nameserver in ${DNS_ZONE_NAMESERVERS}; do

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -16,6 +16,9 @@ set -Eeuo pipefail
 
 source "${KCTF_BIN}/kctf-log"
 
+KCTF_CLOUD_BASE_URL="https://kctf-cloud-staging.appspot.com"
+KCTF_CLOUD_API_KEY="AIzaSyAAzuNBG_dsBTVori26YFmYE-FcNsz-A20"
+
 function create_operator {
   # Creating CRD, rbac and operator
   kubectl apply -f "${KCTF_CTF_DIR}/kctf/resources/kctf.dev_challenges_crd.yaml"
@@ -34,6 +37,23 @@ function create_operator {
     fi
     sleep 3
   done
+}
+
+function wait_for_nameserver {
+  nameserver="$1"
+  initial_timeout=180
+  timeout=$initial_timeout
+  sleep_time=10
+  while [[ "${timeout}" -gt 0 ]]; do
+    if nslookup -nosearch -norecurse -type=NS "${DOMAIN_NAME}." "${nameserver}" >/dev/null 2>/dev/null; then
+      return 0
+    fi
+    _kctf_log "nameserver didn't serve NS record yet, sleeping for ${sleep_time}s"
+    sleep ${sleep_time}
+    timeout=$(($timeout - $sleep_time))
+  done
+  _kctf_log_err "nameserver didn't serve NS record after ${initial_timeout}s"
+  return 1
 }
 
 function kctf_cluster_start_gce {
@@ -115,6 +135,30 @@ function kctf_cluster_start_gce {
       fi
       gcloud dns managed-zones create "${ZONE_NAME}" --description "DNS Zone for ${DOMAIN_NAME}" --dns-name="${DOMAIN_NAME}."
     fi
+
+    DNS_ZONE_NAMESERVERS=$(gcloud dns managed-zones describe kctf-cluster-dns-zone --format 'value[delimiter="\n"](nameServers)')
+    if [[ "${DOMAIN_NAME}" == *".kctf.cloud" ]]; then
+      _kctf_log "waiting for nameservers to be updated (should take roughly 1m)"
+      for nameserver in ${DNS_ZONE_NAMESERVERS}; do
+        wait_for_nameserver "${nameserver}"
+      done
+      KCTF_CLOUD_URL="${KCTF_CLOUD_BASE_URL}/subdomain?name=${DOMAIN_NAME%.kctf.cloud}&nameservers=$(paste -sd ',' <(echo "${DNS_ZONE_NAMESERVERS}"))"
+      _kctf_log 'requesting kctf.cloud subdomain'
+      kctf_cloud_tries=3
+      kctf_cloud_timeout=10
+      while true; do
+        curl --fail -X POST -H "x-api-key: ${KCTF_CLOUD_API_KEY}" "${KCTF_CLOUD_URL}" >/dev/null && break
+        kctf_cloud_tries=$(($kctf_cloud_tries - 1))
+        if [[ $kctf_cloud_tries -le 0 ]]; then
+          _kctf_log_err 'could not register kctf.cloud subdomain'
+          exit 1
+        fi
+        _kctf_log_warn "registering kctf.cloud subdomain failed, retrying in ${kctf_cloud_timeout}s"
+        sleep "${kctf_cloud_timeout}"
+      done
+    else
+      # print in red for attention
+      _kctf_log $'\001\e[0;31m\002'"ATTENTION: "$'\001\e[0m\002'"You need to add the following NS entries for your domain \"${DOMAIN_NAME}\":"$'\n'"${DNS_ZONE_NAMESERVERS}"
     fi
 
     DNS_GSA_NAME="kctf-cloud-dns"

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -16,8 +16,8 @@ set -Eeuo pipefail
 
 source "${KCTF_BIN}/kctf-log"
 
-KCTF_CLOUD_BASE_URL="https://kctf-cloud-staging.appspot.com"
-KCTF_CLOUD_API_KEY="AIzaSyAAzuNBG_dsBTVori26YFmYE-FcNsz-A20"
+KCTF_CLOUD_BASE_URL="https://kctf-cloud.appspot.com"
+KCTF_CLOUD_API_KEY="AIzaSyC7Jgu4e0IygmImZNPmJHrcfZ3lJA9ZrZs"
 
 function create_operator {
   # Creating CRD, rbac and operator

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -17,6 +17,7 @@ set -Eeuo pipefail
 source "${KCTF_BIN}/kctf-log"
 
 KCTF_CLOUD_BASE_URL="https://kctf-cloud.appspot.com/v1"
+# owned by kctf-cloud
 KCTF_CLOUD_API_KEY="AIzaSyC7Jgu4e0IygmImZNPmJHrcfZ3lJA9ZrZs"
 
 function create_operator {

--- a/dist/bin/kctf-completion
+++ b/dist/bin/kctf-completion
@@ -143,6 +143,10 @@ function _kctf_complete_config() {
           COMPREPLY=($(compgen -W "${GCP_REGISTRIES}" -- "${COMP_WORDS[${COMP_CWORD}]}"))
           return
         fi
+        if [ "${PREV_WORD}" == "--domain-name" ]; then
+          COMPREPLY=($(compgen -W "none" -- "${COMP_WORDS[${COMP_CWORD}]}"))
+          return
+        fi
         return 0
       fi
       COMPREPLY=($(compgen -W "--help --type --project --zone --registry --cluster-name --domain-name --start-cluster" -- "${COMP_WORDS[${COMP_CWORD}]}"))

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -241,7 +241,7 @@ function kctf_config_create {
   mkdir -p "${KCTF_CTF_DIR}/kctf/config"
 
   if [ -e "${CONFIG_PATH}" ]; then
-    _kctf_warn "Overwriting existing config file. Old content:"
+    _kctf_log_warn "Overwriting existing config file. Old content:"
     cat "${CONFIG_PATH}" >&2
     rm "${CONFIG_PATH}" >&2
   fi

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -103,8 +103,8 @@ function kctf_config_list {
 function kctf_config_create_usage {
   echo "usage: kctf config create [args] config_name" >&2
   echo "  -h|--help       print this help" >&2
-  echo "  --type          what kind of cluster to create " >&2
-  echo "                  currently supported values: gce (remote) and kind (local)" >&2
+  echo "  --type          what kind of cluster to create (default: gce)" >&2
+  echo "                  supported values: \"gce\" (remote cluster) and \"kind\" (local cluster)" >&2
   echo "  --project       Required (gce): Google Cloud Platform project name" >&2
   echo "  --zone          GCP Zone (default: europe-west4-b)" >&2
   echo "                  For a list of zones run:" >&2

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -105,14 +105,14 @@ function kctf_config_create_usage {
   echo "  -h|--help       print this help" >&2
   echo "  --type          what kind of cluster to create " >&2
   echo "                  currently supported values: gce (remote) and kind (local)" >&2
-  echo "  --project       Google Cloud Platform project name" >&2
+  echo "  --project       Required (gce): Google Cloud Platform project name" >&2
   echo "  --zone          GCP Zone (default: europe-west4-b)" >&2
   echo "                  For a list of zones run:" >&2
   echo "                    gcloud compute machine-types list --filter=\"name=( n2-standard-4 )\" --format 'value(zone)'" >&2
   echo "  --registry      Container Registry (default: eu.gcr.io)" >&2
   echo "                  Possible values are us.gcr.io, asia.gcr.io, and eu.gcr.io" >&2
   echo "  --cluster-name  Name of the kubernetes cluster (default: kctf-cluster)" >&2
-  echo "  --domain-name   Required: domain name to host challenges under" >&2
+  echo "  --domain-name   Required (gce): domain name to host challenges under" >&2
   echo "                  Please make sure not to put anything secret in the challenge name." >&2
   echo "                  Supported options:" >&2
   echo "                    \"none\": disable DNS support (might break some functionality)" >&2
@@ -195,16 +195,6 @@ function kctf_config_create {
     esac
   done
 
-  if [[ -z "${DOMAIN_NAME}" ]]; then
-    _kctf_log_err "kctf config create: --domain-name required"
-    kctf_config_create_usage
-    return 1
-  fi
-
-  if [[ "${DOMAIN_NAME}" == "none" ]]; then
-    DOMAIN_NAME=""
-  fi
-
   if [[ $# -ne 1 ]]; then
     _kctf_log_err "kctf config create: config name missing"
     kctf_config_create_usage
@@ -229,6 +219,11 @@ function kctf_config_create {
         kctf_config_create_usage
         return 1
       fi
+      if [[ -z "${DOMAIN_NAME}" ]]; then
+        _kctf_log_err "Missing required argument \"--domain-name\"."
+        kctf_config_create_usage
+        return 1
+      fi
       ;;
     kind)
       ;;
@@ -237,6 +232,11 @@ function kctf_config_create {
       return 1
       ;;
   esac
+
+  if [[ "${DOMAIN_NAME}" == "none" ]]; then
+    DOMAIN_NAME=""
+  fi
+
 
   mkdir -p "${KCTF_CTF_DIR}/kctf/config"
 

--- a/dist/bin/kctf-config
+++ b/dist/bin/kctf-config
@@ -101,22 +101,28 @@ function kctf_config_list {
 }
 
 function kctf_config_create_usage {
-  echo -e "usage: kctf config create [args] config_name" >&2
-  echo -e "  -h|--help       print this help" >&2
-  echo -e "  --type          what kind of cluster to create " >&2
-  echo -e "                  currently supported values: gce (remote) and kind (local)" >&2
-  echo -e "  --project       Google Cloud Platform project name" >&2
-  echo -e "  --zone          GCP Zone (default: europe-west4-b)" >&2
-  echo -e "                  For a list of zones run:" >&2
-  echo -e "                    gcloud compute machine-types list --filter=\"name=( n2-standard-4 )\" --format 'value(zone)'" >&2
-  echo -e "  --registry      Container Registry (default: eu.gcr.io)" >&2
-  echo -e "                  Possible values are us.gcr.io, asia.gcr.io, and eu.gcr.io" >&2
-  echo -e "  --cluster-name  Name of the kubernetes cluster (default: kctf-cluster)" >&2
-  echo -e "  --domain-name   Optional domain name to host challenges under" >&2
-  echo -e "  --email-address Optional email address for LetsEncrypt registration (for wildcard certificates)" >&2
-  echo -e "                  To use it, please read and agree to the ACME Subscriber Agreement:" >&2
-  echo -e "                    https://letsencrypt.org/repository/" >&2
-  echo -e "  --start-cluster Start the cluster if it's not running yet" >&2
+  echo "usage: kctf config create [args] config_name" >&2
+  echo "  -h|--help       print this help" >&2
+  echo "  --type          what kind of cluster to create " >&2
+  echo "                  currently supported values: gce (remote) and kind (local)" >&2
+  echo "  --project       Google Cloud Platform project name" >&2
+  echo "  --zone          GCP Zone (default: europe-west4-b)" >&2
+  echo "                  For a list of zones run:" >&2
+  echo "                    gcloud compute machine-types list --filter=\"name=( n2-standard-4 )\" --format 'value(zone)'" >&2
+  echo "  --registry      Container Registry (default: eu.gcr.io)" >&2
+  echo "                  Possible values are us.gcr.io, asia.gcr.io, and eu.gcr.io" >&2
+  echo "  --cluster-name  Name of the kubernetes cluster (default: kctf-cluster)" >&2
+  echo "  --domain-name   Required: domain name to host challenges under" >&2
+  echo "                  Please make sure not to put anything secret in the challenge name." >&2
+  echo "                  Supported options:" >&2
+  echo "                    \"none\": disable DNS support (might break some functionality)" >&2
+  echo "                    \"your.domain.com\": use your own domain. You will have to follow some" >&2
+  echo "                                         additional steps to configure your nameserver." >&2
+  echo "                    \"yourname.kctf.cluster\": automatically get a subdomain under kctf.cluster" >&2
+  echo "  --email-address Optional email address for LetsEncrypt registration (for wildcard certificates)" >&2
+  echo "                  To use it, please read and agree to the ACME Subscriber Agreement:" >&2
+  echo "                    https://letsencrypt.org/repository/" >&2
+  echo "  --start-cluster Start the cluster if it's not running yet" >&2
 }
 
 function kctf_config_create {
@@ -188,6 +194,16 @@ function kctf_config_create {
         ;;
     esac
   done
+
+  if [[ -z "${DOMAIN_NAME}" ]]; then
+    _kctf_log_err "kctf config create: --domain-name required"
+    kctf_config_create_usage
+    return 1
+  fi
+
+  if [[ "${DOMAIN_NAME}" == "none" ]]; then
+    DOMAIN_NAME=""
+  fi
 
   if [[ $# -ne 1 ]]; then
     _kctf_log_err "kctf config create: config name missing"

--- a/dist/bin/kctf-log
+++ b/dist/bin/kctf-log
@@ -23,7 +23,7 @@ function _kctf_log {
   echo "$@" >&2
 }
 
-function _kctf_warn {
+function _kctf_log_warn {
   echo -n "${_KCTF_COLOR_YELLOW}[W]${_KCTF_COLOR_END} " >&2
   echo "$@" >&2
 }

--- a/dist/challenge-templates/pwn/challenge.yaml
+++ b/dist/challenge-templates/pwn/challenge.yaml
@@ -7,6 +7,5 @@ spec:
   powDifficultySeconds: 0
   network:
     public: false
-    dns: true
   healthcheck:
     enabled: true

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -26,7 +26,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY --from=build /build/chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
+FROM gcr.io/kctf-docker/challenge@sha256:f73360b379aee583ab2442f5d2a45c17d5b30a5f7f1c7333b969cec9767dd439
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
+FROM gcr.io/kctf-docker/healthcheck@sha256:33e4b50046701011d3f57d0e76fa0611ec4ca09556b6e15843bad1c2ed709302
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/web/challenge.yaml
+++ b/dist/challenge-templates/web/challenge.yaml
@@ -7,7 +7,6 @@ spec:
   powDifficultySeconds: 0
   network:
     public: false
-    dns: true
     ports:
     - protocol: "HTTPS"
       targetPort: 1337

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 
 RUN mkdir -p /home/user/chroot
 
-FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
+FROM gcr.io/kctf-docker/challenge@sha256:f73360b379aee583ab2442f5d2a45c17d5b30a5f7f1c7333b969cec9767dd439
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
+FROM gcr.io/kctf-docker/healthcheck@sha256:33e4b50046701011d3f57d0e76fa0611ec4ca09556b6e15843bad1c2ed709302
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/challenge-templates/xss-bot/challenge.yaml
+++ b/dist/challenge-templates/xss-bot/challenge.yaml
@@ -7,6 +7,5 @@ spec:
   powDifficultySeconds: 0
   network:
     public: false
-    dns: true
   healthcheck:
     enabled: true

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:28ac8a790fe2005ce5693161be70fab2a1b9b405e1cee7a815ebbf41954f629a
+FROM gcr.io/kctf-docker/challenge@sha256:f73360b379aee583ab2442f5d2a45c17d5b30a5f7f1c7333b969cec9767dd439
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:742859cf51de52446e919cb3c2a96965c1fe44924e93762b99723920428dce03
+FROM gcr.io/kctf-docker/healthcheck@sha256:33e4b50046701011d3f57d0e76fa0611ec4ca09556b6e15843bad1c2ed709302
 
 COPY healthz.py /home/user/
 COPY doit.py /home/user/

--- a/dist/resources/kctf.dev_challenges_crd.yaml
+++ b/dist/resources/kctf.dev_challenges_crd.yaml
@@ -93,12 +93,8 @@ spec:
                 description: Image used by the deployment
                 type: string
               network:
-                description: 'The network specifications: if it''s public or not,
-                  if it uses dns or not and specifications about ports'
+                description: 'The network specifications: if it''s public or not and specifications about ports'
                 properties:
-                  dns:
-                    default: false
-                    type: boolean
                   ports:
                     description: By default, one port is set with default values
                     items:

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:f332cc59dd3e43a9efd04658470823eacfdf29ab077ce81cba2bec536e438d48
+          image: gcr.io/kctf-docker/kctf-operator@sha256:f357c7c28874cb8358fba2e41bf8aa9bbd0575f56ad7102811301a2b6b2b40a5
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:06fe29bd3534ee649e7dfcd0a2a83874142c1f42a41ce1d2e08bd9d7034c6ed4
+          image: gcr.io/kctf-docker/kctf-operator@sha256:43db6c4d8445dd294eb589097be9464fda999a0ab7a7f546c3f1fbd806bfd360
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/apis/kctf/v1alpha1/challenge_types.go
+++ b/kctf-operator/pkg/apis/kctf/v1alpha1/challenge_types.go
@@ -31,9 +31,6 @@ type NetworkSpec struct {
 	// +kubebuilder:default:=false
 	Public bool `json:"public,omitempty"`
 
-	// +kubebuilder:default:=false
-	Dns bool `json:"dns,omitempty"`
-
 	// By default, one port is set with default values
 	Ports []PortSpec `json:"ports,omitempty"`
 }
@@ -88,7 +85,7 @@ type ChallengeSpec struct {
 	// +kubebuilder:default:=0
 	PowDifficultySeconds int `json:"powDifficultySeconds,omitempty"`
 
-	// The network specifications: if it's public or not, if it uses dns or not and specifications about ports
+	// The network specifications: if it's public or not and specifications about ports
 	Network NetworkSpec `json:"network,omitempty"`
 
 	// Healthcheck checks if the challenge works

--- a/kctf-operator/pkg/controller/challenge/dns/functions.go
+++ b/kctf-operator/pkg/controller/challenge/dns/functions.go
@@ -68,10 +68,9 @@ func Update(challenge *kctfv1alpha1.Challenge, client client.Client, scheme *run
 		"challengeName", challenge.Name,
 		"certificateExists", certificateExists,
 		"ingressExists", ingressExists,
-		"domainName", domainName,
-		"challenge.Spec.Network.Dns", challenge.Spec.Network.Dns)
+		"domainName", domainName)
 
-	if !ingressExists || !challenge.Spec.Network.Dns || domainName == "" {
+	if !ingressExists || domainName == "" {
 		// No certificate required.
 		// Note that we don't delete the certificate here since creation takes a long time so we might want to reuse it in the future.
 		return false, nil

--- a/kctf-operator/pkg/controller/challenge/service/service.go
+++ b/kctf-operator/pkg/controller/challenge/service/service.go
@@ -141,10 +141,8 @@ func generateLoadBalancerService(domainName string, challenge *kctfv1alpha1.Chal
 		service.Spec.Ports = append(service.Spec.Ports, servicePort)
 	}
 
-	if challenge.Spec.Network.Dns == true {
-		service.ObjectMeta.Annotations =
-			map[string]string{"external-dns.alpha.kubernetes.io/hostname": challenge.Name + "." + domainName}
-	}
+	service.ObjectMeta.Annotations =
+		map[string]string{"external-dns.alpha.kubernetes.io/hostname": challenge.Name + "." + domainName}
 
 	return service
 }

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,7 +5,7 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:bfd9884f7ca9c0ba5ccf61dd62d09a7c8056a7d82d663da11e79f19ca4b8a7ed"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:dcfdfe7eb04edeb3e5094d69a9d164901aa873ac52b650b543b90f853807912e"
 const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:f2d17b8383e63e51aff7d9ca8429db8f0b0ab73323713d858c3258bad5f8287f"
 
 // .. ^^ ........................... ^^ ..

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,8 +5,8 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:3b765f36c11c425931f38a9e71ea1dd8309dca1d5fac86fd2fda50800382d4d9"
-const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:3bc4ee2b5f902f4545bddd1afa70276a95bc9bdebe1d986e57ed1ea8f6ec4d84"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:bfd9884f7ca9c0ba5ccf61dd62d09a7c8056a7d82d663da11e79f19ca4b8a7ed"
+const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:f2d17b8383e63e51aff7d9ca8429db8f0b0ab73323713d858c3258bad5f8287f"
 
 // .. ^^ ........................... ^^ ..
 // == || These are set by automation || ==


### PR DESCRIPTION
Now, --domain-name is required for type=gce and you can set it to "none" or a domain.
If you choose kctf.cloud as a domain, we create a subdomain for you.

This made the dns option obsolete, so removing it (assume always true).

TODO: kctf.cloud needs to be added to the public suffix list.

Fixes #213
Fixes #195 