### PR TITLE
Readme: fix link to samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Additional documentation resources are:
 
 ## Samples
 
-The [samples](https://github.com/google/kctf/tree/master/samples) directory contains two examples:
+The [samples](https://github.com/google/kctf/tree/beta/dist/challenge-templates/) directory contains two examples:
 * A web challenge that acts like an XSS bot.
 * A web challenge that acts like a vulnerable PHP application with support for sessions and file uploads.
 


### PR DESCRIPTION
Folder and branch don't exist anymore since they got moved in https://github.com/google/kctf/commit/7df254a43fc822e73c09edae872f2767b12f3219
This at least fixes it in the Readme