### PR TITLE
Adding mention of SSH/VPN to tunnel traffic.

### DIFF
--- a/docs/security-threat-model.md
+++ b/docs/security-threat-model.md
@@ -25,6 +25,7 @@ As such, the risks in this area are:
 
 Ways to limit these risks are:
  - Players could connect to the tasks through HTTPS. However, there are currently no plans to implement this functionality.
+ - Players may 'tunnel' via VPN/SSH to a protected proxy device from which they then access the CTF.
 
 The compromise of the players themselves is out of scope of kCTF's threat model.
 


### PR DESCRIPTION
Small change here, want to mention that a trusted server can be used as a 'proxy' (jumpbox) for accessing the challenge.  Having players tunnel directly to that trusted server can help avoid MiTM style interception of their connections.