### PR TITLE
Dont build in docker

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -196,6 +196,9 @@ jobs:
           kctf chal create --template $template $template
           echo "entering challenge directory ${template}"
           pushd $template
+            if [[ -e "challenge/Makefile" ]]; then
+              make -C "challenge"
+            fi
             sed -i "s/public: false/public: true/" challenge.yaml
             CHALLENGE_NAME="$("${KCTF_BIN}/yq" eval '.metadata.name' challenge.yaml)"
             echo "starting challenge ${CHALLENGE_NAME}"

--- a/dist/challenge-templates/pwn/README.md
+++ b/dist/challenge-templates/pwn/README.md
@@ -6,6 +6,7 @@ The basic steps when preparing a challenge are:
 * Edit `challenge/Dockerfile` to change the commandline or the files you want to include.
 * To try the challenge locally, you will need to
   * create a a local cluster with `kctf cluster create --type kind --start $configname`
+  * build the challenge binary with `make -C challenge`
   * and then deploy the challenge with `kctf chal start`
 * To access the challenge, create a port forward with `kctf chal debug port-forward` and connect to it via `nc localhost PORT` using the printed port.
 * Check out `kctf chal <tab>` for more commands.
@@ -25,8 +26,11 @@ For documentation on the available fields, you can run `kubectl explain challeng
 ### /challenge
 
 The `challenge` directory contains a Dockerfile that describes the challenge and
-any challenge files. You can use the Dockerfile to build your challenge as well
-if required.
+any challenge files. This template comes with a Makefile to build the challenge,
+which is the recommended way for pwnables if the deployed binary matters, e.g.
+if you hand it out as an attachment for ROP gadgets.
+If the binary layout doesn't matter, you can build it using an intermediate
+container as part of the Dockerfile similar to how the chroot is created.
 
 ### /healthcheck
 

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -11,20 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:20.04 as build
-
-RUN apt-get update && apt-get install -yq --no-install-recommends build-essential
-
-RUN mkdir /build
-COPY chal.c /build/
-RUN make -C /build chal
-
 FROM ubuntu:20.04 as chroot
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 
 COPY flag /
-COPY --from=build /build/chal /home/user/
+COPY chal /home/user/
 
 FROM gcr.io/kctf-docker/challenge@sha256:460c2fdc4467e4aac23d3efe7a91a42049bef0fe788e6fed15f8acf018ad94ca
 

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -18,7 +18,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:460c2fdc4467e4aac23d3efe7a91a42049bef0fe788e6fed15f8acf018ad94ca
+FROM gcr.io/kctf-docker/challenge@sha256:e550af5df266cb89a26ace1ba5dcc685981f01d1cb61e45a898cce0c9753de7a
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/challenge/Makefile
+++ b/dist/challenge-templates/pwn/challenge/Makefile
@@ -1,0 +1,1 @@
+chal: chal.c

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:64aec023da1b95d108cf3c065b6167ac47c054ef0936be42d7c6d14115cefa73
+FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
 
 RUN mkdir -p /home/user/chroot
 
-FROM gcr.io/kctf-docker/challenge@sha256:460c2fdc4467e4aac23d3efe7a91a42049bef0fe788e6fed15f8acf018ad94ca
+FROM gcr.io/kctf-docker/challenge@sha256:e550af5df266cb89a26ace1ba5dcc685981f01d1cb61e45a898cce0c9753de7a
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:64aec023da1b95d108cf3c065b6167ac47c054ef0936be42d7c6d14115cefa73
+FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:460c2fdc4467e4aac23d3efe7a91a42049bef0fe788e6fed15f8acf018ad94ca
+FROM gcr.io/kctf-docker/challenge@sha256:e550af5df266cb89a26ace1ba5dcc685981f01d1cb61e45a898cce0c9753de7a
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:64aec023da1b95d108cf3c065b6167ac47c054ef0936be42d7c6d14115cefa73
+FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:9abd4559a3a5cc3e9d64b3e7314bdf93fb749f49c112af83868dfd9d216316d0
+          image: gcr.io/kctf-docker/kctf-operator@sha256:f16c645a40d31aa72fd21c21c60d4b8ae517338575455310368239361f77804e
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/docs/google-cloud.md
+++ b/docs/google-cloud.md
@@ -114,10 +114,16 @@ In the next step, you'll find out how to deploy the newly created challenge.
 To deploy the challenge, run the following command, which builds and deploys the challenge, **but doesn't expose it to the internet**:
 
 ```bash
-kctf chal start
+make -C challenge && kctf chal start
 ```
 
 This command deploys the image to your cluster, which will soon start consuming CPU resources. The challenge automatically scales based on CPU usage.
+
+Note that the pwn template comes with a Makefile to build the challenge binary.
+This is recommended if you want to hand out the binary as an attachment to
+players, e.g. since the layout might matter for ROP gadgets. If the layout
+doesn't matter, you could also build it in an intermediate container as part
+of your Dockerfile.
 
 ## Expose your challenge to the internet
 

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -88,9 +88,15 @@ You should then notice that the prompt detected that you are inside of a challen
 evn@evn:~/ctf-directory/chal-sample$ kCTF[ctf=ctf-directory,config=local-cluster,chal=chal-sample] > 
 ```
 
+The pwn template comes with a Makefile to build the challenge binary. This is
+recommended if you want to hand out the binary as an attachment to players,
+e.g. since the layout might matter for ROP gadgets. If the layout doesn't
+matter, you could also build it in an intermediate container as part of your
+Dockerfile.
+
 To start the challenge, run:
 ```bash
-kctf chal start
+make -C challenge && kctf chal start
 ```
 
 Once the challenge is built and deployed, you will see `challenge.kctf.dev/chal-sample created`.
@@ -119,7 +125,7 @@ To test what would happen if the challenge broke, we can modify the task, and se
 
 Run the following command to replace `cat /flag` with `echo /flag` in `challenge/chal.c`:
 ```bash
-sed -i s/cat/echo/ challenge/chal.c 
+sed -i s/cat/echo/ challenge/chal.c && make -C challenge
 ```
 
 If you try to connect again, you will notice that the old version is still running (you will still see `CTF{TestFlag}`).

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,8 +5,8 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:8f2b414491c570d0aef2e7cc8f74f5b5dd0d54ca7fdae5ce96b4397c9ff9e285"
-const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:618bf1f1a353b21a4e4ebe1c30701533c91d0f6793bfd152386e6573f95758d6"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:4b649785c2fd9e063eb3aa36c100590e07dcb2e8f422f469a0ce814c3619847f"
+const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:85f4eac10e254651ab3ff531869b86c3b542d2dd9d0d1dbf8724a552b42ab970"
 
 // .. ^^ ........................... ^^ ..
 // == || These are set by automation || ==


### PR DESCRIPTION
In pwnables, the binary layout often matters for ROP gadgets etc. I.e. you want to hand out the binary as an attachment.
This also means that if you make a small change in the Dockerfile and redeploy, it will currently rebuild the binary which will make it out of sync with the file that players received.

To fix this, we leave building the binary up to the player and recommend to do it in the Dockerfile if the binary layout doesn't matter.

So now, for deploying a pwnable, the dev should run `make -C challenge && kctf chal start` to make it explicit that they want to change the binary.