### PR TITLE
Make mounts optional

### DIFF
--- a/dist/challenge-templates/web/challenge/cgi-bin.nsjail.cfg
+++ b/dist/challenge-templates/web/challenge/cgi-bin.nsjail.cfg
@@ -49,9 +49,20 @@ mount: [
     is_bind: true
   },
   {
+    dst: "/mnt/disks/sessions"
+    fstype: "tmpfs"
+    rw: true
+  },
+  {
     src: "/mnt/disks/sessions"
     dst: "/mnt/disks/sessions"
     is_bind: true
+    rw: true
+    mandatory: false
+  },
+  {
+    dst: "/mnt/disks/uploads"
+    fstype: "tmpfs"
     rw: true
   },
   {
@@ -59,6 +70,7 @@ mount: [
     dst: "/mnt/disks/uploads"
     is_bind: true
     rw: true
+    mandatory: false
   },
   {
     dst: "/tmp"


### PR DESCRIPTION
Tested this with:
```bash
$ docker run -v $PWD:/mnt/disks/sessions --privileged -it $(docker build -q .) nsjail --config home/user/cgi-bin.nsjail.cfg -- /bin/bash -c 'ls /mnt/disks/*'
```

