### PR TITLE
enumerate all capabilities in setpriv

### DIFF
--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -18,7 +18,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:6dd60da626bc43bf3175d9d7436006db5acc7710d5d1b7006ab53e718fe51e40
+FROM gcr.io/kctf-docker/challenge@sha256:53499279053b1dace64197f0376b972793f1131c6b0fa317edf23fe1b0933b61
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
+FROM gcr.io/kctf-docker/healthcheck@sha256:60267abf2e5a081f3f26692ebecac29a8a315a413f69cb1bfcd2e9148dda116e
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -40,7 +40,7 @@ COPY web-servers /web-servers
 
 COPY flag /
 
-FROM gcr.io/kctf-docker/challenge@sha256:6dd60da626bc43bf3175d9d7436006db5acc7710d5d1b7006ab53e718fe51e40
+FROM gcr.io/kctf-docker/challenge@sha256:53499279053b1dace64197f0376b972793f1131c6b0fa317edf23fe1b0933b61
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends tzdata apache2 \

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
+FROM gcr.io/kctf-docker/healthcheck@sha256:60267abf2e5a081f3f26692ebecac29a8a315a413f69cb1bfcd2e9148dda116e
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:6dd60da626bc43bf3175d9d7436006db5acc7710d5d1b7006ab53e718fe51e40
+FROM gcr.io/kctf-docker/challenge@sha256:53499279053b1dace64197f0376b972793f1131c6b0fa317edf23fe1b0933b61
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:06c6f051583b84d8dc4d77962256b7d1f1f247f405972e0649c821837b66c894
+FROM gcr.io/kctf-docker/healthcheck@sha256:60267abf2e5a081f3f26692ebecac29a8a315a413f69cb1bfcd2e9148dda116e
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/docker-images/challenge/Dockerfile
+++ b/docker-images/challenge/Dockerfile
@@ -16,12 +16,13 @@
 FROM ubuntu:20.04 as nsjail
 
 ENV BUILD_PACKAGES build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev ca-certificates
+ENV NSJAIL_COMMIT 4be95952340bd1339889174d3a9158d636985813
 
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends $BUILD_PACKAGES \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/google/nsjail.git \
-    && cd /nsjail && make -j && cp nsjail /usr/bin/ \
+    && cd /nsjail && git checkout $NSJAIL_COMMIT && make -j && cp nsjail /usr/bin/ \
     && rm -R /nsjail && apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto)
 
 # challenge image

--- a/docker-images/challenge/kctf_drop_privs
+++ b/docker-images/challenge/kctf_drop_privs
@@ -2,4 +2,9 @@
 
 # There are two copies of this file in the nsjail and healthcheck base images.
 
-exec setpriv --init-groups --reset-env --reuid user --regid user --inh-caps=-all -- "$@"
+all_caps="-cap_0"
+for i in $(seq 1 $(cat /proc/sys/kernel/cap_last_cap)); do
+  all_caps+=",-cap_${i}"
+done
+
+exec setpriv --init-groups --reset-env --reuid user --regid user --inh-caps=${all_caps} -- "$@"

--- a/docker-images/healthcheck/kctf_drop_privs
+++ b/docker-images/healthcheck/kctf_drop_privs
@@ -2,4 +2,9 @@
 
 # There are two copies of this file in the nsjail and healthcheck base images.
 
-exec setpriv --init-groups --reset-env --reuid user --regid user --inh-caps=-all -- $@
+all_caps="-cap_0"
+for i in $(seq 1 $(cat /proc/sys/kernel/cap_last_cap)); do
+  all_caps+=",-cap_${i}"
+done
+
+exec setpriv --init-groups --reset-env --reuid user --regid user --inh-caps=${all_caps} -- $@


### PR DESCRIPTION
Using -all in setpriv requires the libcap to be in sync with the host kernel.
Since we don't control the host kernel, we can't ship a working libcap.
Instead, we check how many caps the kernel supports (from /proc) and drop all of those.