### PR TITLE
allow setting container capabilities in challenge.yaml

### DIFF
--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:09367cbd2efcfb0888ea1140f1b1ba6185e78404b5eaa59d6dab4e7ae8d17335
+          image: gcr.io/kctf-docker/kctf-operator@sha256:da3488551fd9d9988d0086dabef6d167a6953032f4e5835bcb249d618dfd84f3
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:da3488551fd9d9988d0086dabef6d167a6953032f4e5835bcb249d618dfd84f3
+          image: gcr.io/kctf-docker/kctf-operator@sha256:a517370bc714a05e1cdec597f8e42033b54267fe2f09baddd18eebbb2486cb35
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/kctf-operator/pkg/controller/challenge/deployment/deployment.go
+++ b/kctf-operator/pkg/controller/challenge/deployment/deployment.go
@@ -61,13 +61,18 @@ func deployment(challenge *kctfv1.Challenge) *appsv1.Deployment {
 	deployment.Spec.Template.Spec.Containers[idx_challenge].Ports = containerPorts(challenge)
 	// Set other container's configurations
 	deployment.Spec.Template.Spec.Containers[idx_challenge].Image = challenge.Spec.Image
-	deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext = &corev1.SecurityContext{
-		Capabilities: &corev1.Capabilities{
+	if deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext == nil {
+		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext = &corev1.SecurityContext{}
+	}
+	if deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.ReadOnlyRootFilesystem == nil {
+		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.ReadOnlyRootFilesystem = &readOnlyRootFilesystem
+	}
+	if deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities == nil {
+		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities = &corev1.Capabilities{
 			Add: []corev1.Capability{
 				"SYS_ADMIN",
 			},
-		},
-		ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
+		}
 	}
 
 	deployment.Spec.Template.Spec.Containers[idx_challenge].Resources = corev1.ResourceRequirements{

--- a/kctf-operator/pkg/controller/challenge/deployment/deployment.go
+++ b/kctf-operator/pkg/controller/challenge/deployment/deployment.go
@@ -68,12 +68,11 @@ func deployment(challenge *kctfv1.Challenge) *appsv1.Deployment {
 		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.ReadOnlyRootFilesystem = &readOnlyRootFilesystem
 	}
 	if deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities == nil {
-		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities = &corev1.Capabilities{
-			Add: []corev1.Capability{
-				"SYS_ADMIN",
-			},
-		}
+		deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities = &corev1.Capabilities{};
 	}
+    
+	deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities.Add =
+		append(deployment.Spec.Template.Spec.Containers[idx_challenge].SecurityContext.Capabilities.Add, "SYS_ADMIN")
 
 	deployment.Spec.Template.Spec.Containers[idx_challenge].Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{


### PR DESCRIPTION
We were always overwriting the capabilities of the challenge container so it was not possible to add custom caps.
Change this by checking for existence before overwriting.

Note that I'm not merging the Capabilities.Add list, instead the challenge author will have to add SYS_ADMIN manually if they want to change it.