### PR TITLE
Make kctf pow use gmp to match speed of alt implementations

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -22,19 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     outputs:
-      kctf-operator-modified: ${{ steps.set-modified.outputs.kctf-operator-modified }}
       challenge-modified: ${{ steps.set-modified.outputs.challenge-modified }}
       healthcheck-modified: ${{ steps.set-modified.outputs.healthcheck-modified }}
       gcsfuse-modified: ${{ steps.set-modified.outputs.gcsfuse-modified }}
       certbot-modified: ${{ steps.set-modified.outputs.certbot-modified }}
-      kctf-operator-digest: ${{ steps.push.outputs.kctf-operator-digest }}
       challenge-digest: ${{ steps.push.outputs.challenge-digest }}
       healthcheck-digest: ${{ steps.push.outputs.healthcheck-digest }}
       gcsfuse-digest: ${{ steps.push.outputs.gcsfuse-digest }}
       certbot-digest: ${{ steps.push.outputs.certbot-digest }}
     strategy:
       matrix:
-        image: ["challenge", "healthcheck", "gcsfuse", "certbot", "kctf-operator"]
+        image: ["challenge", "healthcheck", "gcsfuse", "certbot"]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -43,11 +41,7 @@ jobs:
     - id: modified
       name: Check for modified paths
       run: |
-        if [ "${{ matrix.image }}" == "kctf-operator" ]; then
-          PATHS=(".github/workflows/update-images.yaml" "kctf-operator/*" "kctf-operator/build/**" "kctf-operator/cmd/**" "kctf-operator/pkg/**" "kctf-operator/version/**")
-        else
-          PATHS=(".github/workflows/update-images.yaml" "docker-images/${{ matrix.image }}/**")
-        fi
+        PATHS=(".github/workflows/update-images.yaml" "docker-images/${{ matrix.image }}/**")
 
         BASE_SHA="$(git log -n1 --grep='Automated commit: update images.' --format=%H || echo '')"
         echo "BASE_SHA=${BASE_SHA}"
@@ -78,16 +72,8 @@ jobs:
     - name: Build image
       if: steps.modified.outputs.modified
       run: |
-        if [ "${{ matrix.image }}" == "kctf-operator" ]; then
-          cd kctf-operator
-          curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-x86_64-linux-gnu -o operator-sdk
-          chmod u+x operator-sdk
-          sudo mv operator-sdk /usr/local/bin/
-          /usr/local/bin/operator-sdk build "${{ matrix.image }}"
-        else
-          cd "docker-images/${{ matrix.image }}"
-          docker build . --tag "${{ matrix.image }}"
-        fi
+        cd "docker-images/${{ matrix.image }}"
+        docker build . --tag "${{ matrix.image }}"
 
     - name: Setup gcloud CLI
       if: steps.modified.outputs.modified
@@ -111,10 +97,86 @@ jobs:
         DIGEST="$(docker push "$IMAGE_GCR" | grep 'digest: ' | sed 's/.*\(sha256:[^ ]*\).*/\1/')"
         echo "::set-output name=${{ matrix.image }}-digest::${DIGEST}"
 
+  build-operator:
+    runs-on: ubuntu-latest
+    needs:
+    - build-docker
+    if: github.event_name == 'push'
+    outputs:
+      kctf-operator-modified: ${{ steps.set-modified.outputs.kctf-operator-modified }}
+      kctf-operator-digest: ${{ steps.push.outputs.kctf-operator-digest }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          fetch-depth: 0
+          
+    - id: modified
+      name: Check for modified paths
+      run: |
+        PATHS=(".github/workflows/update-images.yaml" "kctf-operator/*" "kctf-operator/build/**" "kctf-operator/cmd/**" "kctf-operator/pkg/**" "kctf-operator/version/**")
+
+        BASE_SHA="$(git log -n1 --grep='Automated commit: update images.' --format=%H || echo '')"
+        echo "BASE_SHA=${BASE_SHA}"
+        if [ -z "${BASE_SHA}" ]; then
+          # we couldn't find any existing robot commit, just rebuild everything
+          echo "::set-output name=modified::true"
+          exit 0
+        fi
+        CHANGED_FILES="$(git diff --name-only ${BASE_SHA} ${{ github.sha }})"
+        echo "CHANGED_FILES=${CHANGED_FILES}"
+
+        while IFS= read -r changed_file; do
+          for watched_path in "${PATHS[@]}"; do
+            if [[ $changed_file == $watched_path ]]; then
+              echo "modified=true: ${changed_file} matches ${watched_path}"
+              echo "::set-output name=modified::true"
+              exit 0
+            fi
+          done
+        done <<< "${CHANGED_FILES}"
+
+    - id: set-modified
+      name: Set modified
+      run: |
+        echo "::set-output name=kctf-operator-modified::${{ steps.modified.outputs.modified }}"
+
+    - name: Build image
+      if: steps.modified.outputs.modified
+      run: |
+        ls -l
+        cd kctf-operator
+        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.18.2/operator-sdk-v0.18.2-x86_64-linux-gnu -o operator-sdk
+        chmod u+x operator-sdk
+        sudo mv operator-sdk /usr/local/bin/
+        /usr/local/bin/operator-sdk build kctf-operator
+
+    - name: Setup gcloud CLI
+      if: steps.modified.outputs.modified
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        version: '319.0.0'
+        service_account_email: ${{ secrets.GCR_EMAIL }}
+        service_account_key: ${{ secrets.GCR_KEY }}
+
+    - name: Configure docker to use the gcloud command-line tool as a credential helper
+      if: steps.modified.outputs.modified
+      run: |
+        gcloud auth configure-docker
+
+    - id: push
+      name: Push images
+      if: steps.modified.outputs.modified
+      run: |
+        IMAGE_GCR="gcr.io/${{ secrets.GCR_PROJECT }}/kctf-operator"
+        docker tag "kctf-operator" "$IMAGE_GCR"
+        DIGEST="$(docker push "$IMAGE_GCR" | grep 'digest: ' | sed 's/.*\(sha256:[^ ]*\).*/\1/')"
+        echo "::set-output name=kctf-operator-digest::${DIGEST}"
+
   update-image-and-commit:
     runs-on: ubuntu-latest
     needs:
     - build-docker
+    - build-operator
     steps:
     - uses: actions/checkout@v2
 
@@ -151,9 +213,9 @@ jobs:
         sed -i 's%const DOCKER_CERTBOT_IMAGE = .*%const DOCKER_CERTBOT_IMAGE = "'${IMAGE}'"%' kctf-operator/pkg/resources/constants.go
 
     - name: Update operator
-      if: needs.build-docker.outputs.kctf-operator-modified
+      if: needs.build-operator.outputs.kctf-operator-modified
       run: |
-        IMAGE="gcr.io/kctf-docker/kctf-operator@${{ needs.build-docker.outputs.kctf-operator-digest }}"
+        IMAGE="gcr.io/kctf-docker/kctf-operator@${{ needs.build-operator.outputs.kctf-operator-digest }}"
         sed -i "s#image: .*#image: ${IMAGE}#" dist/resources/operator.yaml
 
     - name: Download kubectl

--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -18,7 +18,7 @@ RUN /usr/sbin/useradd --no-create-home -u 1000 user
 COPY flag /
 COPY chal /home/user/
 
-FROM gcr.io/kctf-docker/challenge@sha256:56f7dddff69d08d4d19f4921c724d438cf4d59e434c601f9776fd818368b7107
+FROM gcr.io/kctf-docker/challenge@sha256:456de9cb229a2f20bf67b78c641937b8aa85596f76917f79f97f88db2d94242b
 
 COPY --from=chroot / /chroot
 

--- a/dist/challenge-templates/pwn/healthcheck/Dockerfile
+++ b/dist/challenge-templates/pwn/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:57c1002a2a8b8741bd2f6b9ee3e1da2c5b3872459b789255895bb8cdf297b911
+FROM gcr.io/kctf-docker/healthcheck@sha256:a11bb188568e5157b01afbf64299575f50f9acc3c2e0aec5b2dc519c5388f2f2
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -40,7 +40,7 @@ COPY web-servers /web-servers
 
 COPY flag /
 
-FROM gcr.io/kctf-docker/challenge@sha256:56f7dddff69d08d4d19f4921c724d438cf4d59e434c601f9776fd818368b7107
+FROM gcr.io/kctf-docker/challenge@sha256:456de9cb229a2f20bf67b78c641937b8aa85596f76917f79f97f88db2d94242b
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends tzdata apache2 \

--- a/dist/challenge-templates/web/healthcheck/Dockerfile
+++ b/dist/challenge-templates/web/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:57c1002a2a8b8741bd2f6b9ee3e1da2c5b3872459b789255895bb8cdf297b911
+FROM gcr.io/kctf-docker/healthcheck@sha256:a11bb188568e5157b01afbf64299575f50f9acc3c2e0aec5b2dc519c5388f2f2
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/challenge@sha256:56f7dddff69d08d4d19f4921c724d438cf4d59e434c601f9776fd818368b7107
+FROM gcr.io/kctf-docker/challenge@sha256:456de9cb229a2f20bf67b78c641937b8aa85596f76917f79f97f88db2d94242b
 
 RUN apt-get update && apt-get install -y gnupg2
 

--- a/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
+++ b/dist/challenge-templates/xss-bot/healthcheck/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM gcr.io/kctf-docker/healthcheck@sha256:57c1002a2a8b8741bd2f6b9ee3e1da2c5b3872459b789255895bb8cdf297b911
+FROM gcr.io/kctf-docker/healthcheck@sha256:a11bb188568e5157b01afbf64299575f50f9acc3c2e0aec5b2dc519c5388f2f2
 
 COPY healthcheck_loop.sh healthcheck.py healthz_webserver.py /home/user/
 

--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kctf-operator
       containers:
         - name: kctf-operator
-          image: gcr.io/kctf-docker/kctf-operator@sha256:72e587201d532cc77de7b791d51ea35917b5808e0335807ab93481997067e874
+          image: gcr.io/kctf-docker/kctf-operator@sha256:aa1a073ca30bd6c8f3e521e57b9f0ec2961f93c09970238b8259d5007ba02f84
           command:
           - kctf-operator
           imagePullPolicy: Always

--- a/docker-images/challenge/Dockerfile
+++ b/docker-images/challenge/Dockerfile
@@ -29,15 +29,15 @@ RUN apt-get update \
 FROM ubuntu:20.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends python3.8 python3-pip uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
+    && apt-get install -yq --no-install-recommends python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 
 COPY --from=nsjail /usr/bin/nsjail /usr/bin/nsjail
 
-# ecdsa used by the proof of work
-RUN python3 -m pip install ecdsa
+# gmpy2 and ecdsa used by the proof of work
+RUN python3 -m pip install ecdsa gmpy2
 
 # we need a clean proc to allow nsjail to remount it in the user namespace
 RUN mkdir /kctf

--- a/docker-images/challenge/Dockerfile
+++ b/docker-images/challenge/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 FROM ubuntu:20.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
+    && apt-get install -yq --no-install-recommends build-essential python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user

--- a/docker-images/challenge/Dockerfile
+++ b/docker-images/challenge/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 FROM ubuntu:20.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends build-essential python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
+    && apt-get install -yq --no-install-recommends build-essential python3-dev python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user

--- a/kctf-operator/pkg/controller/challenge/pow/configmap.go
+++ b/kctf-operator/pkg/controller/challenge/pow/configmap.go
@@ -11,7 +11,7 @@ import (
 // Generates the configmap that contains the how difficult should be the proof of work
 func generate(challenge *kctfv1.Challenge) *corev1.ConfigMap {
 	data := map[string]string{
-		"pow.conf": strconv.Itoa(challenge.Spec.PowDifficultySeconds * 133) + "\n",
+		"pow.conf": strconv.Itoa(challenge.Spec.PowDifficultySeconds * 1337) + "\n",
 	}
 	configmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/kctf-operator/pkg/controller/challenge/pow/configmap.go
+++ b/kctf-operator/pkg/controller/challenge/pow/configmap.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Generates the configmap that contains the how difficult should be the proof of work
+// Generates the configmap that contains how difficult should be the proof of work
 func generate(challenge *kctfv1.Challenge) *corev1.ConfigMap {
 	data := map[string]string{
 		"pow.conf": strconv.Itoa(challenge.Spec.PowDifficultySeconds * 1337) + "\n",

--- a/kctf-operator/pkg/resources/constants.go
+++ b/kctf-operator/pkg/resources/constants.go
@@ -5,8 +5,8 @@ package resources
 // == || These are set by automation || ==
 // .. vv ........................... vv ..
 
-const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:82be4c84fad2a11a6b92aa472cab2dd7018178ab89f27d4d77f46997ff539229"
-const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:b3e780cd860d3566bd91e6cc5a39e55377a33c22ff521b393f14947852967831"
+const DOCKER_CERTBOT_IMAGE = "gcr.io/kctf-docker/certbot@sha256:187812484b5bdb63a94f27e82b50f0aa5bf8c87a569518da3e7847ca4c261031"
+const DOCKER_GCSFUSE_IMAGE = "gcr.io/kctf-docker/gcsfuse@sha256:851fc799147368818b3005573236b0066698f3d784c17a89d19a2bf188836533"
 
 // .. ^^ ........................... ^^ ..
 // == || These are set by automation || ==


### PR DESCRIPTION
It has been clearly pointed out that GMP is 10x faster than python3's built-in math implementation

https://github.com/redpwn/pow
https://github.com/Aplet123/kctf-pow

This change allows the pow to use gmpy2 in order to match the same speed as these other alternative implementations.
