### PR TITLE
MacOS compatibility

### DIFF
--- a/dist/activate
+++ b/dist/activate
@@ -12,26 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KCTF_YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64"
-KCTF_YQ_HASH="5d44bd64e264e9029c5f06bcd960ba162d7ed7ddd1781f02a28d62f50577b632"
+if [[ "$OSTYPE" =~ ^darwin.* ]]; then
+  KCTF_YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_darwin_amd64"
+  KCTF_YQ_HASH="83b9dc96e75799e162035b2ee2dffc0c51de869c27a2e294eb0aee8653a19804"
 
-KCTF_KIND_URL="https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64"
-KCTF_KIND_HASH="949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491"
+  KCTF_KIND_URL="https://kind.sigs.k8s.io/dl/v0.11.1/kind-darwin-amd64"
+  KCTF_KIND_HASH="432bef555a70e9360b44661c759658265b9eaaf7f75f1beec4c4d1e6bbf97ce3"
 
-KCTF_KUBECTL_URL="https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kubectl"
-KCTF_KUBECTL_HASH="98e8aea149b00f653beeb53d4bd27edda9e73b48fed156c4a0aa1dabe4b1794c"
+  KCTF_KUBECTL_URL="https://dl.k8s.io/release/v1.20.4/bin/darwin/amd64/kubectl"
+  KCTF_KUBECTL_HASH="37f593731b8c9913bf2a3bfa36dacb3058dc176c7aeae2930c783822ea03a573"
+
+  STAT="gstat"
+  MKTEMP="gmktemp"
+else
+  KCTF_YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64"
+  KCTF_YQ_HASH="5d44bd64e264e9029c5f06bcd960ba162d7ed7ddd1781f02a28d62f50577b632"
+
+  KCTF_KIND_URL="https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64"
+  KCTF_KIND_HASH="949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491"
+
+  KCTF_KUBECTL_URL="https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kubectl"
+  KCTF_KUBECTL_HASH="98e8aea149b00f653beeb53d4bd27edda9e73b48fed156c4a0aa1dabe4b1794c"
+  
+  STAT="stat"
+  MKTEMP="mktemp"
+fi
 
 export KCTF_CTF_DIR="$(realpath --no-symlinks "$(dirname "${BASH_SOURCE-$0}")/..")"
 export KCTF_BIN="${KCTF_CTF_DIR}/kctf/bin"
 source "${KCTF_BIN}/kctf-log"
-
-if [[ "$OSTYPE" =~ ^darwin.* ]]; then
-  STAT="gstat"
-  MKTEMP="gmktemp"
-else
-  STAT="stat"
-  MKTEMP="mktemp"
-fi
 
 function _kctf_check_umask {
   if [[ $((8#$(umask) & 8#755)) -ne 0 ]]; then

--- a/dist/activate
+++ b/dist/activate
@@ -25,19 +25,27 @@ export KCTF_CTF_DIR="$(realpath --no-symlinks "$(dirname "${BASH_SOURCE-$0}")/..
 export KCTF_BIN="${KCTF_CTF_DIR}/kctf/bin"
 source "${KCTF_BIN}/kctf-log"
 
+if [[ "$OSTYPE" =~ ^darwin.* ]]; then
+  STAT="gstat"
+  MKTEMP="gmktemp"
+else
+  STAT="stat"
+  MKTEMP="mktemp"
+fi
+
 function _kctf_check_umask {
   if [[ $((8#$(umask) & 8#755)) -ne 0 ]]; then
     _kctf_log_err "umask is too prohibitive. Please set it to 022 when using kctf"
     return 1
   fi
-  if [[ "$(stat "${KCTF_BIN}/kctf-cluster" --format '%a')" -ne "755" ]]; then
+  if [[ "$(${STAT} "${KCTF_BIN}/kctf-cluster" --format '%a')" -ne "755" ]]; then
     _kctf_log_err "${KCTF_BIN}/kctf-cluster has unexpected permissions. Maybe a umask problem during checkout?"
     return 1
   fi
 }
 
 function _kctf_setup_environment {
-  KCTF_CONFIG_DIR="$(mktemp -d --tmpdir kctf.XXXXXXXXXX)"
+  KCTF_CONFIG_DIR="$(${MKTEMP} -d --tmpdir kctf.XXXXXXXXXX)"
   if [[ $? -ne 0 ]]; then
     return 1
   fi

--- a/dist/bin/kctf-challenge
+++ b/dist/bin/kctf-challenge
@@ -15,6 +15,12 @@
 
 source "${KCTF_BIN}/kctf-log"
 
+if [[ "$OSTYPE" =~ ^darwin.* ]]; then
+  GETOPT="$(brew --prefix gnu-getopt)/bin/getopt"
+else
+  GETOPT="getopt"
+fi
+
 function has_cluster_config {
   [[ ! -z "${CLUSTER_NAME-}" ]]
 }
@@ -45,7 +51,7 @@ function parse_help_arg_only_usage {
 function parse_help_arg_only {
   OPTS="h"
   LONGOPTS="help"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
   if [[ $? -ne 0 ]]; then
     parse_help_arg_only_usage
     exit 1
@@ -82,7 +88,7 @@ function parse_container_name_usage {
 function parse_container_name {
   OPTS="h"
   LONGOPTS="help,container:"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
   if [[ $? -ne 0 ]]; then
     parse_container_name_usage
     exit 1
@@ -245,7 +251,7 @@ function kctf_chal_debug_logs {
 
   OPTS="h"
   LONGOPTS="help,container:,tail:"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal ${COMMAND}" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_chal_debug_logs_usage
     exit 1
@@ -346,7 +352,7 @@ function kctf_chal_debug_port_forward {
 
   OPTS="h"
   LONGOPTS="help,challenge-name:,port:,local-port:"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal debug port-forward" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal debug port-forward" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_chal_debug_port_forward_usage
     exit 1
@@ -462,7 +468,7 @@ function kctf_chal_create_usage {
 function kctf_chal_create {
   OPTS="h"
   LONGOPTS="help,template:,challenge-dir:"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal create" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal create" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_chal_create_usage
     exit 1

--- a/dist/bin/kctf-cluster
+++ b/dist/bin/kctf-cluster
@@ -20,6 +20,12 @@ KCTF_CLOUD_BASE_URL="https://kctf-cloud.appspot.com/v1"
 # owned by kctf-cloud
 KCTF_CLOUD_API_KEY="AIzaSyC7Jgu4e0IygmImZNPmJHrcfZ3lJA9ZrZs"
 
+if [[ "$OSTYPE" =~ ^darwin.* ]]; then
+  GETOPT="$(brew --prefix gnu-getopt)/bin/getopt"
+else
+  GETOPT="getopt"
+fi
+
 function update_gcloud_config {
   _kctf_log "Updating gcloud config."
   ACTIVE_ACCOUNT="$(CLOUDSDK_ACTIVE_CONFIG_NAME= gcloud config get-value core/account 2>/dev/null)"
@@ -146,7 +152,7 @@ function kctf_cluster_create {
 
   OPTS="h"
   LONGOPTS="help,type:,project:,zone:,registry:,cluster-name:,domain-name:,email-address:,start"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf cluster create" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf cluster create" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_cluster_create_usage
     return 1
@@ -344,7 +350,7 @@ function kctf_cluster_ip_ranges {
 
   OPTS="h"
   LONGOPTS="help"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf cluster set-src-ip-ranges" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf cluster set-src-ip-ranges" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_cluster_ip_ranges_usage
     return 1
@@ -742,7 +748,7 @@ function kctf_cluster_resize {
 
   OPTS="h"
   LONGOPTS="help,machine-type:,min-nodes:,max-nodes:,num-nodes:,pool-name:,old-pool"
-  PARSED=$(getopt --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal create" -- "$@")
+  PARSED=$(${GETOPT} --options=$OPTS --longoptions=$LONGOPTS --name "kctf chal create" -- "$@")
   if [[ $? -ne 0 ]]; then
     kctf_cluster_resize_usage
     exit 1


### PR DESCRIPTION
Requires the user:
`brew install coreutils gnu-getopt`

Added binaries for x64 Darwin, but arm64 (m1) could be added as well.