### PR TITLE
Upgrade external-dns to 0.10

### DIFF
--- a/dist/resources/operator.yaml
+++ b/dist/resources/operator.yaml
@@ -4544,7 +4544,7 @@ spec:
           value: 0.0.0.0/0
         - name: SECURITY_POLICY
           value: DISABLED
-        image: gcr.io/kctf-docker/kctf-operator@sha256:12d5b1132b01434f0977e856cd700d98e18fdbfdaaa9959ad25335eb06e83d88
+        image: gcr.io/kctf-docker/kctf-operator@sha256:bd6625c3e2ef29605651dd1c5191df7b1f8644cd78b312a2b9abf3a3377ee557
         livenessProbe:
           httpGet:
             path: /healthz

--- a/kctf-operator/resources/external-dns.go
+++ b/kctf-operator/resources/external-dns.go
@@ -74,7 +74,7 @@ func NewExternalDnsDeployment() client.Object {
 					ServiceAccountName: "external-dns-sa",
 					Containers: []corev1.Container{
 						{
-							Image: "us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.2",
+							Image: "us.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.10.0",
 							Name:  "external-dns",
 							Env: []corev1.EnvVar{{
 								Name: "DOMAIN_NAME",


### PR DESCRIPTION
We need this because Kubernetes 1.22 isn't compatible with <0.10