### PR TITLE
docs: fix port used in connection for local-testing.md

### DIFF
--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -109,7 +109,7 @@ kctf chal debug port-forward &
 
 After connecting, you will see `Forwarding from 127.0.0.1:[LOCAL_PORT] -> 1337` in the terminal. Connect to the LOCAL_PORT:
 ```bash
-nc 127.0.0.1 [external_port]
+nc 127.0.0.1 [LOCAL_PORT]
 ```
 
 If all went well, you should be able to connect and see:


### PR DESCRIPTION
This section of the doc was slightly confusing at first glance.
The doc says:

```
Connect to the LOCAL_PORT:

nc 127.0.0.1 [external_port]
```

But it really should be `LOCAL_PORT`.
For example:

```
> kctf chal debug port-forward &
[1] 21137
[*] starting port-forward, ctrl+c to exit
Forwarding from 127.0.0.1:43373 -> 1337

> nc localhost 43373
== proof-of-work: disabled ==
CTF{TestFlag}
```
