### PR TITLE
Fix two bugs in xss-bot

### DIFF
--- a/dist/challenge-templates/xss-bot/challenge/bot.js
+++ b/dist/challenge-templates/xss-bot/challenge/bot.js
@@ -53,10 +53,10 @@ if (BLOCK_SUBORIGINS) {
     const page = await context.newPage();
     await page.setCookie(cookie);
     socket.write(`Loading page ${url}.\n`);
-    await page.goto(url);
+    page.goto(url);
     setTimeout(()=>{
       try {
-        page.close();
+        context.close();
         socket.write('timeout\n');
         socket.destroy();
       } catch (err) {


### PR DESCRIPTION
`await page.goto(url)` can take forever if a page loads infinite image for example
`page.close()` only closes one page which makes other opened tabs stay forever.