### PR TITLE
Be more resilient to host/challenge glibc mismatch (#384)

### DIFF
--- a/dist/challenge-templates/pwn/challenge/Makefile
+++ b/dist/challenge-templates/pwn/challenge/Makefile
@@ -1,1 +1,3 @@
+LDFLAGS=-static
+
 chal: chal.c


### PR DESCRIPTION
Because the challenge runtime container and host build environment might
diverge, link the sample challenge statically to give a higher
likelihood that it can still run inside the challenge container.