### PR TITLE
Fix no Chrome found error

### DIFF
--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -68,7 +68,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 COPY bot.js /home/user/
 COPY cookie /home/user/
 COPY .puppeteerrc.cjs /home/user/
-RUN cd /home/user && npm install puppeteer
+RUN cd /home/user && npm install puppeteer && node node_modules/puppeteer/install.js
+RUN cp -r /root/.cache /home/user/
 
 ENV DOMAIN="www.example.com"
 # Hosting multiple web challenges same-site to each other can lead to

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -68,7 +68,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 COPY bot.js /home/user/
 COPY cookie /home/user/
 COPY .puppeteerrc.cjs /home/user/
-RUN cd /home/user && npm install puppeteer && node node_modules/puppeteer/install.js
+RUN cd /home/user && npm install puppeteer
 RUN cp -r /root/.cache /home/user/
 
 ENV DOMAIN="www.example.com"

--- a/dist/challenge-templates/xss-bot/challenge/Dockerfile
+++ b/dist/challenge-templates/xss-bot/challenge/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y gnupg2 wget
 #  plus libxshmfence1 which seems to be missing
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && wget -q -O - https://deb.nodesource.com/setup_16.x | bash - \
+    && wget -q -O - https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
         ca-certificates \


### PR DESCRIPTION
Since puppeteer 19.0.0. the browser is loaded from `~/.cache/`. Maybe not the cleanest fix but it works.

https://github.com/puppeteer/puppeteer/issues/9533


```
Node.js v18.16.0
/home/user/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:300
                    throw new Error(Could not find Chrome (ver. ${this.puppeteer.browserRevision}). This can occur if either\n +
                          ^

Error: Could not find Chrome (ver. 113.0.5672.63). This can occur if either
 1. you did not perform an installation before running the script (e.g. npm install) or
 2. your cache path is incorrectly configured (which is: /home/user/.cache/puppeteer).
For (2), check out our guide on configuring puppeteer at https://pptr.dev/guides/configuration.
    at ChromeLauncher.resolveExecutablePath (/home/user/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:300:27)
    at ChromeLauncher.executablePath (/home/user/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ChromeLauncher.js:181:25)
    at ChromeLauncher.computeLaunchArguments (/home/user/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ChromeLauncher.js:97:37)
    at async ChromeLauncher.launch (/home/user/node_modules/puppeteer-core/lib/cjs/puppeteer/node/ProductLauncher.js:83:28)
    at async /home/user/bot.js:121:19

Node.js v18.16.0
```