### PR TITLE
Add both DOMAIN and *.DOMAIN

### DIFF
--- a/docker-images/certbot/certbot.sh
+++ b/docker-images/certbot/certbot.sh
@@ -26,7 +26,7 @@ else
 fi
 
 function request_certificate() {
-  certbot certonly ${TEST} --non-interactive --agree-tos ${EMAIL_FLAG} --dns-google -d '*.'"${DOMAIN}" --dns-google-propagation-seconds 120
+  certbot certonly ${TEST} --non-interactive --agree-tos ${EMAIL_FLAG} --dns-google -d "${DOMAIN}" -d '*.'"${DOMAIN}" --dns-google-propagation-seconds 120
 }
 
 function update_tls_secret() {


### PR DESCRIPTION
Currently, the cert only works for `*.${DOMAIN}` but having a root cert should also be nice to have, especially when running the same image for a single challenge. 