### PR TITLE
Image update: ubuntu to 24.04, gcsfuse to 1.x, nsjail to latest

### DIFF
--- a/dist/challenge-templates/pwn/challenge/Dockerfile
+++ b/dist/challenge-templates/pwn/challenge/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:20.04 as chroot
+FROM ubuntu:24.04 as chroot
 
 RUN /usr/sbin/useradd --no-create-home -u 1000 user
 

--- a/dist/challenge-templates/web/challenge/Dockerfile
+++ b/dist/challenge-templates/web/challenge/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:20.04 as chroot
+FROM ubuntu:24.04 as chroot
 
 RUN /usr/sbin/useradd -u 1000 user
 

--- a/docker-images/certbot/Dockerfile
+++ b/docker-images/certbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y certbot python3-certbot-dns-google curl jq
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && chmod +x kubectl
 COPY certbot.sh certbot.sh

--- a/docker-images/challenge/Dockerfile
+++ b/docker-images/challenge/Dockerfile
@@ -13,31 +13,32 @@
 # limitations under the License.
 
 # build nsjail first
-FROM ubuntu:20.04 as nsjail
+FROM ubuntu:24.04 as nsjail
 
 ENV BUILD_PACKAGES build-essential git protobuf-compiler libprotobuf-dev bison flex pkg-config libnl-route-3-dev ca-certificates
-ENV NSJAIL_COMMIT f920c9194ec1e9654f051eb2390604059c951ea2
+ENV NSJAIL_COMMIT 3677ccbe45b184bd4600415cbfb48762a2735674
 
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends $BUILD_PACKAGES \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/google/nsjail.git \
     && cd /nsjail && git checkout $NSJAIL_COMMIT && make -j && cp nsjail /usr/bin/ \
-    && rm -R /nsjail && apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto)
+    && rm -R /nsjail
 
 # challenge image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update \
-    && apt-get install -yq --no-install-recommends build-essential python3-dev python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf17 libnl-route-3-200 wget netcat ca-certificates socat \
+    && apt-get install -yq --no-install-recommends build-essential python3-dev python3.8 python3-pip libgmp3-dev libmpc-dev uidmap libprotobuf32t64 libnl-route-3-200 wget netcat-traditional ca-certificates socat \
     && rm -rf /var/lib/apt/lists/*
 
-RUN /usr/sbin/useradd --no-create-home -u 1000 user
+# ubuntu24 includes the ubuntu user by default
+RUN /usr/sbin/userdel -r ubuntu && /usr/sbin/useradd --no-create-home -u 1000 user
 
 COPY --from=nsjail /usr/bin/nsjail /usr/bin/nsjail
 
 # gmpy2 and ecdsa used by the proof of work
-RUN python3 -m pip install ecdsa gmpy2
+RUN python3 -m pip install --break-system-packages ecdsa gmpy2
 
 # we need a clean proc to allow nsjail to remount it in the user namespace
 RUN mkdir /kctf

--- a/docker-images/gcsfuse/Dockerfile
+++ b/docker-images/gcsfuse/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y wget fuse
-RUN wget -q https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v0.35.1/gcsfuse_0.35.1_amd64.deb && dpkg -i gcsfuse_0.35.1_amd64.deb
+RUN wget -q https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.4.2/gcsfuse_1.4.2_amd64.deb && dpkg -i gcsfuse_1.4.2_amd64.deb
 RUN mkdir -p /mnt/disks/gcs
 
 CMD test -f /config/gcs_bucket &&\

--- a/docker-images/healthcheck/Dockerfile
+++ b/docker-images/healthcheck/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,19 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ENV BUILD_PACKAGES python3-pip build-essential python3-dev
 
 RUN apt-get update \
     && apt-get -yq --no-install-recommends install $BUILD_PACKAGES \
     && rm -rf /var/lib/apt/lists/* \
-    && python3 -m pip install pwntools \
-    && apt-get remove --purge -y $BUILD_PACKAGES $(apt-mark showauto)
+    && python3 -m pip install --break-system-packages pwntools \
+    && apt-get remove --purge -y $BUILD_PACKAGES && apt-get autoremove -y
 
 RUN apt-get update && apt-get -yq --no-install-recommends install cpio openssl python3 && rm -rf /var/lib/apt/lists/*
 
-RUN /usr/sbin/useradd --no-create-home -u 1000 user
+# ubuntu24 includes the ubuntu user by default
+RUN /usr/sbin/userdel -r ubuntu && /usr/sbin/useradd --no-create-home -u 1000 user
 
 RUN mkdir -p /home/user/.pwntools-cache && echo never > /home/user/.pwntools-cache/update
 


### PR DESCRIPTION
Bumping all the (very) old dependencies our containers have.
To be honest I'm not sure how to test it other than trying to deploy it to a cluster (after it builds&releases). The images build fine, but eg. something nonobvious could have broken in gcsfuse.