### PR TITLE
Update update-images.yaml

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -181,7 +181,7 @@ jobs:
     - name: 'Setup go version necessary for operator'
       uses: actions/setup-go@v5
       with:
-        go-version: 'latest'
+        go-version: '1.24.1'
 
     - name: Build image
       if: steps.modified.outputs.modified

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -89,9 +89,9 @@ jobs:
         credentials_json: '${{ secrets.GKE_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
+      uses: 'google-github-actions/setup-gcloud@v2'
       with:
-        version: '319.0.0'
+        version: 'latest'
         service_account_email: ${{ secrets.GKE_EMAIL }}
 
     - name: Configure docker to use the gcloud command-line tool as a credential helper

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -187,7 +187,7 @@ jobs:
       if: steps.modified.outputs.modified
       run: |
         cd kctf-operator
-        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64 -o operator-sdk
+        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64 -o operator-sdk
         chmod u+x operator-sdk
         sudo mv operator-sdk /usr/local/bin/
         make controller-gen

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7.17'
+        python-version: '3.13.2'
 
     - name: 'Set up Cloud SDK auth'
       uses: 'google-github-actions/auth@v0'

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -187,6 +187,7 @@ jobs:
       if: steps.modified.outputs.modified
       run: |
         cd kctf-operator
+        sudo apt install -y etcd
         curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64 -o operator-sdk
         chmod u+x operator-sdk
         sudo mv operator-sdk /usr/local/bin/

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -179,9 +179,9 @@ jobs:
         gcloud auth configure-docker
 
     - name: 'Setup go version necessary for operator'
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.16.0'
+        go-version: 'latest'
 
     - name: Build image
       if: steps.modified.outputs.modified

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -186,8 +186,9 @@ jobs:
     - name: Build image
       if: steps.modified.outputs.modified
       run: |
+        curl -L https://storage.googleapis.com/etcd/v3.5.19/etcd-v3.5.19-linux-amd64.tar.gz -o /tmp/etcd.tar.gz
+        sudo tar xzvf /tmp/etcd.tar.gz -C /usr/local/bin/ --strip-components=1
         cd kctf-operator
-        sudo apt-get update && sudo apt install -y etcd
         curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64 -o operator-sdk
         chmod u+x operator-sdk
         sudo mv operator-sdk /usr/local/bin/

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -162,15 +162,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.13.2'
 
     - name: Export gcloud related env variable
       run: export CLOUDSDK_PYTHON="/usr/bin/python3"
     
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
+      uses: 'google-github-actions/setup-gcloud@v2'
       with:
-        version: '319.0.0'
+        version: 'latest'
         service_account_email: ${{ secrets.GKE_EMAIL }}
 
     - name: Configure docker to use the gcloud command-line tool as a credential helper
@@ -257,7 +257,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.13.2'
 
     - name: Export gcloud related env variable
       run: export CLOUDSDK_PYTHON="/usr/bin/python3"
@@ -271,7 +271,7 @@ jobs:
         credentials_json: '${{ secrets.GKE_KEY }}'
 
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
+      uses: 'google-github-actions/setup-gcloud@v2'
       with:
         service_account_email: ${{ secrets.GKE_EMAIL }}
         install_components: 'gke-gcloud-auth-plugin'

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.7'
+        python-version: '3.7.17'
 
     - name: 'Set up Cloud SDK auth'
       uses: 'google-github-actions/auth@v0'

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -187,7 +187,7 @@ jobs:
       if: steps.modified.outputs.modified
       run: |
         cd kctf-operator
-        sudo apt install -y etcd
+        sudo apt-get update && sudo apt install -y etcd
         curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64 -o operator-sdk
         chmod u+x operator-sdk
         sudo mv operator-sdk /usr/local/bin/

--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -187,7 +187,7 @@ jobs:
       if: steps.modified.outputs.modified
       run: |
         cd kctf-operator
-        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.39.2/operator-sdk_linux_amd64 -o operator-sdk
+        curl -L https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64 -o operator-sdk
         chmod u+x operator-sdk
         sudo mv operator-sdk /usr/local/bin/
         make controller-gen

--- a/kctf-operator/Makefile
+++ b/kctf-operator/Makefile
@@ -134,7 +134,7 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -143,7 +143,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/kctf-operator/Makefile
+++ b/kctf-operator/Makefile
@@ -124,7 +124,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.2)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.


### PR DESCRIPTION
The action fails after ubuntu update, saying that 3.7 is not available. https://github.com/google/kctf/actions/runs/13995620258/job/39189928063#step:6:334

The newest non-alpha version listed in https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json available on Ubuntu 24.04 is 3.13.2

Also update setup-gcloud to v2 and use the latest version